### PR TITLE
fix: LlamaStack RBAC template to auto-construct serviceAccountName from inferenceServiceName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.jsonl
 .DS_Store
 demos/llamastack/Llama_Stack_NVIDIA_E2E_Flow_include_outputs.ipynb
+
+# Demo scripts directory (contains sensitive tokens and real credentials)
+demo-scripts/

--- a/deploy/nemo-instances/templates/llamastack/deployment.yaml
+++ b/deploy/nemo-instances/templates/llamastack/deployment.yaml
@@ -1,4 +1,27 @@
 {{- if .Values.llamastack.enabled }}
+{{- /* Auto-construct serviceAccountName from inferenceServiceName if not explicitly set */}}
+{{- $serviceAccountName := .Values.llamastack.serviceAccountName }}
+{{- if not $serviceAccountName }}
+  {{- if .Values.llamastack.inferenceServiceName }}
+    {{- $serviceAccountName = printf "%s-sa" .Values.llamastack.inferenceServiceName }}
+  {{- else }}
+    {{- fail "Either llamastack.serviceAccountName or llamastack.inferenceServiceName must be set" }}
+  {{- end }}
+{{- end }}
+{{- /* Auto-construct inferenceServicePredictor from inferenceServiceName if not explicitly set */}}
+{{- $inferenceServicePredictor := .Values.llamastack.inferenceServicePredictor }}
+{{- if not $inferenceServicePredictor }}
+  {{- if .Values.llamastack.inferenceServiceName }}
+    {{- $inferenceServicePredictor = printf "%s-predictor" .Values.llamastack.inferenceServiceName }}
+  {{- else }}
+    {{- fail "Either llamastack.inferenceServicePredictor or llamastack.inferenceServiceName must be set" }}
+  {{- end }}
+{{- end }}
+{{- /* Determine InferenceService namespace (defaults to main namespace) */}}
+{{- $inferenceServiceNamespace := .Values.llamastack.inferenceServiceNamespace }}
+{{- if not $inferenceServiceNamespace }}
+  {{- $inferenceServiceNamespace = .Values.namespace.name }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -32,7 +55,7 @@ spec:
         "openshift.io/scc": "nonroot"
         "sidecar.istio.io/inject": "true"
     spec:
-      serviceAccountName: {{ .Values.llamastack.serviceAccountName }}
+      serviceAccountName: {{ $serviceAccountName }}
       containers:
         - name: llamastack-ctr
           image: {{ .Values.llamastack.image.repository }}:{{ .Values.llamastack.image.tag }}
@@ -64,7 +87,12 @@ spec:
                   key: {{ .Values.llamastack.ngcAPISecret.key }}
             {{- end }}
             - name: NVIDIA_BASE_URL
-              value: "http://{{ .Values.llamastack.inferenceServicePredictor }}.{{ .Values.namespace.name }}.svc.cluster.local:80"
+              {{- if .Values.llamastack.nvidiaBaseURL }}
+              value: {{ .Values.llamastack.nvidiaBaseURL | quote }}
+              {{- else }}
+              # Auto-constructed from inferenceServicePredictor and namespace
+              value: "http://{{ $inferenceServicePredictor }}.{{ $inferenceServiceNamespace }}.svc.cluster.local:80"
+              {{- end }}
             - name: NVIDIA_DATASETS_URL
               value: "http://{{ .Values.datastore.name }}.{{ .Values.namespace.name }}.svc.cluster.local:8000"
             - name: NVIDIA_DATASET_NAMESPACE
@@ -87,7 +115,7 @@ spec:
             - name: NVIDIA_SERVICE_ACCOUNT_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: anemo-rhoai-model-sa-token-secret
+                  name: {{ $serviceAccountName }}-token-secret
                   key: token
             {{- end }}
             - name: LLAMA_STACK_PORT

--- a/deploy/nemo-instances/templates/llamastack/rbac.yaml
+++ b/deploy/nemo-instances/templates/llamastack/rbac.yaml
@@ -1,9 +1,18 @@
 {{- if and .Values.llamastack.enabled .Values.llamastack.useBearerToken }}
+{{- /* Auto-construct serviceAccountName from inferenceServiceName if not explicitly set */}}
+{{- $serviceAccountName := .Values.llamastack.serviceAccountName }}
+{{- if not $serviceAccountName }}
+  {{- if .Values.llamastack.inferenceServiceName }}
+    {{- $serviceAccountName = printf "%s-sa" .Values.llamastack.inferenceServiceName }}
+  {{- else }}
+    {{- fail "Either llamastack.serviceAccountName or llamastack.inferenceServiceName must be set" }}
+  {{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.llamastack.serviceAccountName }}-token-reader
+  name: {{ $serviceAccountName }}-token-reader
   namespace: {{ .Values.namespace.name }}
   labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -11,23 +20,23 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  resourceNames: ["{{ .Values.llamastack.serviceAccountName }}-token-secret"]
+  resourceNames: ["{{ $serviceAccountName }}-token-secret"]
   verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.llamastack.serviceAccountName }}-token-reader
+  name: {{ $serviceAccountName }}-token-reader
   namespace: {{ .Values.namespace.name }}
   labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.llamastack.serviceAccountName }}
+  name: {{ $serviceAccountName }}
   namespace: {{ .Values.namespace.name }}
 roleRef:
   kind: Role
-  name: {{ .Values.llamastack.serviceAccountName }}-token-reader
+  name: {{ $serviceAccountName }}-token-reader
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/deploy/nemo-instances/templates/llamastack/serviceaccount-token-secret.yaml
+++ b/deploy/nemo-instances/templates/llamastack/serviceaccount-token-secret.yaml
@@ -1,12 +1,21 @@
 {{- if and .Values.llamastack.enabled .Values.llamastack.useBearerToken }}
+{{- /* Auto-construct serviceAccountName from inferenceServiceName if not explicitly set */}}
+{{- $serviceAccountName := .Values.llamastack.serviceAccountName }}
+{{- if not $serviceAccountName }}
+  {{- if .Values.llamastack.inferenceServiceName }}
+    {{- $serviceAccountName = printf "%s-sa" .Values.llamastack.inferenceServiceName }}
+  {{- else }}
+    {{- fail "Either llamastack.serviceAccountName or llamastack.inferenceServiceName must be set" }}
+  {{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.llamastack.serviceAccountName }}-token-secret
+  name: {{ $serviceAccountName }}-token-secret
   namespace: {{ .Values.namespace.name }}
   annotations:
-    kubernetes.io/service-account.name: {{ .Values.llamastack.serviceAccountName }}
+    kubernetes.io/service-account.name: {{ $serviceAccountName }}
 type: kubernetes.io/service-account-token
 {{- end }}
 

--- a/deploy/nemo-instances/templates/pre-install-validation.yaml
+++ b/deploy/nemo-instances/templates/pre-install-validation.yaml
@@ -134,8 +134,16 @@ spec:
           
           # Check LlamaStack service account (if LlamaStack is enabled)
           {{- if and .Values.llamastack.enabled .Values.llamastack.useBearerToken }}
+          {{- /* Auto-construct serviceAccountName from inferenceServiceName if not explicitly set */}}
+          {{- $serviceAccountName := .Values.llamastack.serviceAccountName }}
+          {{- if not $serviceAccountName }}
+            {{- if .Values.llamastack.inferenceServiceName }}
+              {{- $serviceAccountName = printf "%s-sa" .Values.llamastack.inferenceServiceName }}
+            {{- end }}
+          {{- end }}
+          {{- if $serviceAccountName }}
           echo "📋 Checking LlamaStack Service Account:"
-          SA_NAME="{{ .Values.llamastack.serviceAccountName }}"
+          SA_NAME="{{ $serviceAccountName }}"
           echo -n "  Checking LlamaStack service account ($SA_NAME)... "
           if oc get sa "$SA_NAME" -n "$NAMESPACE" >/dev/null 2>&1; then
             echo "✅ Found"
@@ -144,6 +152,7 @@ spec:
             # Don't fail - Helm will create it
           fi
           echo ""
+          {{- end }}
           {{- end }}
           
           # Final validation

--- a/deploy/nemo-instances/values.yaml
+++ b/deploy/nemo-instances/values.yaml
@@ -356,22 +356,48 @@ llamastack:
   datasetNamespace: "nvidia-e2e-tutorial"
   projectId: "llamastack-project"
   guardrailsConfigId: "demo-self-check-input-output"
+  # Inference model identifier (optional - defaults to a common model name)
+  # This is used by LlamaStack for model identification in its API
+  # If not specified, defaults to "meta/llama-3.2-1b-instruct"
+  # Only override if you need a different model identifier
   inferenceModel: "meta/llama-3.2-1b-instruct"
+  # Safety model identifier (for guardrails)
   safetyModel: "meta/llama-3.2-1b-instruct"
   outputModelDir: "nvidia-e2e-tutorial/test-messages-model@v1"
+  # REQUIRED: KServe InferenceService name (without -predictor suffix)
+  # This is the name of your InferenceService resource
+  # Example: anemo-rhoai-model1
+  # The template will automatically construct:
+  #   - Service account name: <inferenceServiceName>-sa
+  #   - Predictor service name: <inferenceServiceName>-predictor
+  # Example: If inferenceServiceName is "anemo-rhoai-model1", then:
+  #   - serviceAccountName will be "anemo-rhoai-model1-sa"
+  #   - inferenceServicePredictor will be "anemo-rhoai-model1-predictor"
+  inferenceServiceName: "anemo-rhoai-model1"
+  # InferenceService namespace (optional)
+  # If not set, defaults to the main namespace (namespace.name)
+  # Only set this if your InferenceService is in a different namespace
+  inferenceServiceNamespace: ""
   # Service account name for LlamaStack (typically created by InferenceService)
   # Format: <inferenceservice-name>-sa
-  # Example: anemo-rhoai-model-sa
-  # Set this to match your InferenceService's service account name
-  serviceAccountName: "anemo-rhoai-model-sa"
+  # If not set, will be auto-constructed from inferenceServiceName as: <inferenceServiceName>-sa
+  # Only override this if your service account has a different naming convention
+  serviceAccountName: ""
   # Whether to create the service account (set to false if InferenceService creates it)
   # Default: false (InferenceService typically creates the service account)
   createServiceAccount: false
   # KServe InferenceService predictor service name (cluster-internal)
   # This is the stable service name that routes to the latest revision
   # Format: <inferenceservice-name>-predictor
-  # Example: anemo-rhoai-model-predictor
-  inferenceServicePredictor: "anemo-rhoai-model-predictor"
+  # If not set, will be auto-constructed from inferenceServiceName as: <inferenceServiceName>-predictor
+  # Only override this if your service has a different naming convention
+  inferenceServicePredictor: ""
+  # Direct override for NVIDIA_BASE_URL (optional, advanced)
+  # If set, this will be used instead of auto-constructing from inferenceServicePredictor
+  # Format: http://<service-name>.<namespace>.svc.cluster.local:<port>
+  # Example: http://my-model-predictor.my-namespace.svc.cluster.local:80
+  # If not set, will be auto-constructed from inferenceServicePredictor and namespace
+  nvidiaBaseURL: ""
   # Use Bearer token authentication instead of API key for KServe InferenceService
   # Set to true when using KServe InferenceService that requires service account token
   useBearerToken: true


### PR DESCRIPTION
- Updated rbac.yaml to use same auto-construction logic as deployment.yaml
- Fixes RoleBinding error: subjects[0].name: Required value
- Added troubleshooting section to commands.md for RBAC errors
- Updated llamastack-deploy.sh with error handling and RBAC verification
- All RBAC resources now auto-constructed from inferenceServiceName