### PR TITLE
Fix NeMo Microservices Installation Issues and Add Helm Hooks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# NeMo Microservices Environment Configuration
+# Copy this file to .env and fill in your actual values
+
+# Required: Kubernetes namespace for NeMo deployment
+NAMESPACE="your-namespace"
+
+# Required: NGC API Key for NVIDIA Container Registry and NeMo model access
+# Generate at: https://org.ngc.nvidia.com/setup/api-keys
+# Required services: NGC catalog and Public API Endpoints
+NGC_API_KEY="your-ngc-api-key"
+
+# Required: NVIDIA API Key for remote LLM judge and NVIDIA API catalog
+# Generate at: https://build.nvidia.com
+NVIDIA_API_KEY="your-nvidia-api-key"
+
+# Required: Hugging Face Token for model and dataset access
+# Generate at: https://huggingface.co/settings/tokens
+# Required access: Read permission for model downloads
+HF_TOKEN="your-hf-token"

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ demos/llamastack/Llama_Stack_NVIDIA_E2E_Flow_include_outputs.ipynb
 # Helm values (may contain sensitive URLs and credentials)
 deploy/nemo-infra/values.yaml
 deploy/nemo-instances/values.yaml
+clear_namespace.sh

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Helm charts for deploying NVIDIA NeMo microservices infrastructure and demos on 
 
 ## Storage requirements
 
-Plan and allocate persistent storage for the following. Default sizes are from the Helm chart values; adjust in `values.yaml` (or `values.yaml.sample`) as needed.
+Plan and allocate persistent storage for the following. Default sizes are from the Helm chart values; adjust in `values.yaml` as needed.
 
 | Component | Purpose | Default size | Notes |
 |-----------|---------|--------------|--------|
@@ -40,7 +40,7 @@ To use this repo with your own environment, set configuration in a few places in
 
 | What | Where | Set to |
 |------|--------|--------|
-| **Deployment namespace** | `deploy/nemo-infra/values.yaml` and `deploy/nemo-instances/values.yaml` (copy from `values.yaml.sample`) | Your OpenShift project name |
+| **Deployment namespace** | `deploy/nemo-infra/values.yaml` and `deploy/nemo-instances/values.yaml` | Your OpenShift project name |
 | **Service URLs / InferenceService** | Helm `values.yaml` (e.g. `llamastack.inferenceServiceName`), or RHOAI YAML (e.g. `deploy/rhoai/copilot-llama-stack.yaml` `VLLM_URL`) | Your InferenceService name and namespace |
 | **Demos and notebooks** | `env.donotcommit` in each demo (copy from `env.donotcommit.example`) | `NMS_NAMESPACE`, `NIM_CHAT_URL` / `NIM_MODEL_SERVING_URL_EXTERNAL`, tokens as needed |
 

--- a/README.md
+++ b/README.md
@@ -150,15 +150,25 @@ Before deploying NeMo instances, create the required secrets:
 export NGC_API_KEY="<YOUR_NGC_API_KEY>"
 
 # NGC Image Pull Secret (for pulling images)
-oc create secret docker-registry ngc-secret \
+oc create secret docker-registry nvcrimagepullsecret \
   --docker-server=nvcr.io \
   --docker-username='$oauthtoken' \
   --docker-password=$NGC_API_KEY \
   -n <namespace>
 
 # NGC API Secret (for model downloads)
-oc create secret generic ngc-api-secret \
+oc create secret generic ngc-api \
   --from-literal=NGC_API_KEY=$NGC_API_KEY \
+  -n <namespace>
+
+# NVIDIA API Secret (for NVIDIA API catalog and remote LLM judge)
+oc create secret generic nvidia-api \
+  --from-literal=NVIDIA_API_KEY=$NVIDIA_API_KEY \
+  -n <namespace>
+
+# Hugging Face Token Secret (for HF model/dataset access)
+oc create secret generic hf-secret \
+  --from-literal=HF_TOKEN=$HF_TOKEN \
   -n <namespace>
 ```
 

--- a/commands.md
+++ b/commands.md
@@ -267,19 +267,19 @@ Before installing nemo-instances, you must create NGC secrets for pulling NVIDIA
 export NGC_API_KEY="<ngc-api-key>"
 
 # Create NGC Image Pull Secret (for pulling images from nvcr.io)
-oc create secret docker-registry ngc-secret \
+oc create secret docker-registry nvcrimagepullsecret \
   --docker-server=nvcr.io \
   --docker-username='$oauthtoken' \
   --docker-password=$NGC_API_KEY \
   -n $NAMESPACE
 
 # Create NGC API Secret (for model downloads and API access)
-oc create secret generic ngc-api-secret \
+oc create secret generic ngc-api \
   --from-literal=NGC_API_KEY=$NGC_API_KEY \
   -n $NAMESPACE
 
 # Verify secrets were created
-oc get secret ngc-secret ngc-api-secret -n $NAMESPACE
+oc get secret nvcrimagepullsecret ngc-api -n $NAMESPACE
 ```
 
 **Note**: The pre-install validation hook will automatically check for these secrets and fail with a clear error message if they're missing.

--- a/demos/llamastack/Deploying Custom model.md
+++ b/demos/llamastack/Deploying Custom model.md
@@ -91,7 +91,7 @@ oc create secret generic hf-token \
 ```
 
 **For other registries:**
-- **NGC models**: Use existing `ngc-secret` and `ngc-api-secret` (already configured)
+- **NGC models**: Use existing `nvcrimagepullsecret` and `ngc-api` (already configured)
 - **S3 models**: Create secret with AWS credentials
 - **Local/HTTP models**: May not require authentication
 
@@ -157,9 +157,9 @@ spec:
           tag: latest
           pullPolicy: Always
           pullSecrets:
-          - ngc-secret
+          - nvcrimagepullsecret
 
-        authSecret: ngc-api-secret
+        authSecret: ngc-api
 
         storage:
           pvc:

--- a/deploy/nemo-infra/Chart.lock
+++ b/deploy/nemo-infra/Chart.lock
@@ -33,4 +33,4 @@ dependencies:
   repository: https://volcano-sh.github.io/helm-charts
   version: 1.13.1
 digest: sha256:8b88a79fa228aa34f601ea8ab8d9d2224acf2a424d23d8694e9cb46482d85bc7
-generated: "2026-01-21T11:31:38.902332-05:00"
+generated: "2026-04-15T21:47:42.163671+03:00"

--- a/deploy/nemo-infra/Chart.lock
+++ b/deploy/nemo-infra/Chart.lock
@@ -33,4 +33,4 @@ dependencies:
   repository: https://volcano-sh.github.io/helm-charts
   version: 1.13.1
 digest: sha256:8b88a79fa228aa34f601ea8ab8d9d2224acf2a424d23d8694e9cb46482d85bc7
-generated: "2026-04-15T21:47:42.163671+03:00"
+generated: "2026-04-16T17:47:29.725173+03:00"

--- a/deploy/nemo-infra/Chart.yaml
+++ b/deploy/nemo-infra/Chart.yaml
@@ -3,7 +3,7 @@ name: nemo-infra
 description: NVIDIA NeMo Infrastructure Components Helm Chart for OpenShift
 type: application
 version: 1.0.0
-appVersion: "25.12"
+appVersion: "25.08"
 keywords:
   - nvidia
   - nemo

--- a/deploy/nemo-infra/README.md
+++ b/deploy/nemo-infra/README.md
@@ -2,8 +2,6 @@
 
 A Helm chart for deploying NVIDIA NeMo infrastructure components on OpenShift, including PostgreSQL databases, MLflow, Argo Workflows, Milvus, OpenTelemetry, MinIO, and Volcano Scheduler.
 
-> **Values file**: `values.yaml` is gitignored (it may contain sensitive URLs and credentials). Copy `values.yaml.sample` to `values.yaml` and replace placeholders with your deployment-specific values before installing.
-
 ## Table of Contents
 
 1. [Overview](#overview)

--- a/deploy/nemo-infra/templates/post-install-bind-scc-job.yaml
+++ b/deploy/nemo-infra/templates/post-install-bind-scc-job.yaml
@@ -1,0 +1,54 @@
+# Post-install/post-upgrade job to bind service accounts to nemo-customizer-scc
+# This ensures customizer training jobs have proper permissions
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nemo-infra-bind-scc
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-infra
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: post-install-scc
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 3
+  template:
+    metadata:
+      name: nemo-infra-bind-scc
+    spec:
+      serviceAccountName: nemo-infra-scc-bind-sa
+      restartPolicy: OnFailure
+      containers:
+      - name: bind-scc
+        image: registry.redhat.io/openshift4/ose-cli:latest
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+
+          echo "Binding service accounts to nemo-customizer-scc..."
+
+          # Check if SCC exists
+          if ! oc get scc nemo-customizer-scc &> /dev/null; then
+            echo "WARNING: nemo-customizer-scc not found - may be created later by nemo-instances chart"
+            echo "This is expected if nemo-instances hasn't been installed yet"
+            exit 0
+          fi
+
+          # Bind nemocustomizer-sample service account (will be created by nemo-instances)
+          echo "Checking if nemocustomizer-sample service account exists..."
+          if oc get sa nemocustomizer-sample -n {{ .Values.namespace.name }} &> /dev/null; then
+            oc adm policy add-scc-to-user nemo-customizer-scc \
+              -z nemocustomizer-sample -n {{ .Values.namespace.name }} || echo "  Failed to bind (may already be bound)"
+            echo "✓ Bound nemocustomizer-sample to nemo-customizer-scc"
+          else
+            echo "  nemocustomizer-sample SA not found yet - will be created by nemo-instances chart"
+            echo "  SCC binding will happen via nemo-instances post-install hook"
+          fi
+
+          echo "✓ SCC binding complete"

--- a/deploy/nemo-infra/templates/post-install-bind-scc-rbac.yaml
+++ b/deploy/nemo-infra/templates/post-install-bind-scc-rbac.yaml
@@ -1,0 +1,66 @@
+# RBAC resources for SCC binding job - created first with hook-weight 0
+# ServiceAccount for scc-bind job
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nemo-infra-scc-bind-sa
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-infra
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: post-install-scc
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+---
+# ClusterRole for scc-bind job
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nemo-infra-scc-bind-role
+  labels:
+    app.kubernetes.io/name: nemo-infra
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: post-install-scc
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  verbs: ["get", "list", "use"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "list"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["rolebindings", "clusterrolebindings"]
+  verbs: ["create", "get", "list", "patch", "update"]
+# Required for oc adm policy add-scc-to-user command
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles"]
+  resourceNames: ["system:openshift:scc:nemo-customizer-scc"]
+  verbs: ["bind"]
+---
+# ClusterRoleBinding for scc-bind job
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nemo-infra-scc-bind-binding
+  labels:
+    app.kubernetes.io/name: nemo-infra
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: post-install-scc
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nemo-infra-scc-bind-role
+subjects:
+- kind: ServiceAccount
+  name: nemo-infra-scc-bind-sa
+  namespace: {{ .Values.namespace.name }}

--- a/deploy/nemo-infra/templates/pre-install-adopt-crds-job.yaml
+++ b/deploy/nemo-infra/templates/pre-install-adopt-crds-job.yaml
@@ -1,0 +1,157 @@
+# Pre-install/pre-upgrade job to adopt existing Argo and Volcano CRDs into Helm
+# This prevents "resource already exists" errors when CRDs were previously installed
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nemo-infra-adopt-crds
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-infra
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: pre-install-adopt
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-15"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 3
+  template:
+    metadata:
+      name: nemo-infra-adopt-crds
+    spec:
+      serviceAccountName: nemo-infra-adopt-sa
+      restartPolicy: OnFailure
+      containers:
+      - name: adopt-crds
+        image: registry.redhat.io/openshift4/ose-cli:latest
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+
+          echo "=== Adopting Argo Workflows CRDs ==="
+          ARGO_CRDS=$(oc get crds -o jsonpath='{.items[?(@.spec.group=="argoproj.io")].metadata.name}' 2>/dev/null || echo "")
+
+          if [ -z "$ARGO_CRDS" ]; then
+            echo "No existing Argo Workflows CRDs found"
+          else
+            for crd in $ARGO_CRDS; do
+              echo "Found Argo CRD: $crd - adopting into Helm..."
+
+              # Remove last-applied-configuration annotation
+              oc annotate crd "$crd" kubectl.kubernetes.io/last-applied-configuration- 2>/dev/null || true
+
+              # Clear managedFields to remove field manager conflicts
+              oc patch crd "$crd" --type=json -p='[{"op": "replace", "path": "/metadata/managedFields", "value": []}]' 2>/dev/null || true
+
+              # Add Helm annotations and labels
+              oc annotate crd "$crd" \
+                meta.helm.sh/release-name={{ .Release.Name }} \
+                meta.helm.sh/release-namespace={{ .Values.namespace.name }} \
+                --overwrite 2>/dev/null || true
+
+              oc label crd "$crd" app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
+
+              echo "  ✓ Adopted $crd"
+            done
+            echo "Argo Workflows CRDs adoption complete"
+          fi
+
+          echo ""
+          echo "=== Adopting Volcano CRDs ==="
+          VOLCANO_CRDS=$(oc get crds -o json 2>/dev/null | jq -r '.items[] | select(.spec.group | contains("volcano.sh")) | .metadata.name' 2>/dev/null || echo "")
+
+          if [ -z "$VOLCANO_CRDS" ]; then
+            echo "No existing Volcano CRDs found"
+          else
+            for crd in $VOLCANO_CRDS; do
+              echo "Found Volcano CRD: $crd - adopting into Helm..."
+
+              oc annotate crd "$crd" \
+                meta.helm.sh/release-name={{ .Release.Name }} \
+                meta.helm.sh/release-namespace={{ .Values.namespace.name }} \
+                --overwrite 2>/dev/null || true
+
+              oc label crd "$crd" app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
+
+              echo "  ✓ Adopted $crd"
+            done
+            echo "Volcano CRDs adoption complete"
+          fi
+
+          echo ""
+          echo "=== Adopting Cluster Resources ==="
+
+          # Adopt ClusterRoles
+          CLUSTER_ROLES=$(oc get clusterroles -o json 2>/dev/null | \
+            jq -r '.items[] | select(.metadata.name | contains("nemo-infra") or contains("volcano") or contains("nim-operator")) | .metadata.name' 2>/dev/null || echo "")
+
+          for resource in $CLUSTER_ROLES; do
+            echo "Adopting ClusterRole: $resource"
+            oc annotate clusterrole "$resource" \
+              meta.helm.sh/release-name={{ .Release.Name }} \
+              meta.helm.sh/release-namespace={{ .Values.namespace.name }} \
+              --overwrite 2>/dev/null || true
+            oc label clusterrole "$resource" app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
+          done
+
+          # Adopt ClusterRoleBindings
+          CLUSTER_ROLE_BINDINGS=$(oc get clusterrolebindings -o json 2>/dev/null | \
+            jq -r '.items[] | select(.metadata.name | contains("nemo-infra") or contains("volcano") or contains("nim-operator")) | .metadata.name' 2>/dev/null || echo "")
+
+          for resource in $CLUSTER_ROLE_BINDINGS; do
+            echo "Adopting ClusterRoleBinding: $resource"
+            oc annotate clusterrolebinding "$resource" \
+              meta.helm.sh/release-name={{ .Release.Name }} \
+              meta.helm.sh/release-namespace={{ .Values.namespace.name }} \
+              --overwrite 2>/dev/null || true
+            oc label clusterrolebinding "$resource" app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
+          done
+
+          # Adopt ValidatingWebhookConfigurations
+          WEBHOOKS=$(oc get validatingwebhookconfigurations -o json 2>/dev/null | \
+            jq -r '.items[] | select(.metadata.name | contains("nemo-infra") or contains("volcano") or contains("nim-operator")) | .metadata.name' 2>/dev/null || echo "")
+
+          for resource in $WEBHOOKS; do
+            echo "Adopting ValidatingWebhookConfiguration: $resource"
+            oc patch validatingwebhookconfiguration "$resource" --type=json \
+              -p='[{"op": "replace", "path": "/metadata/managedFields", "value": []}]' 2>/dev/null || true
+            oc annotate validatingwebhookconfiguration "$resource" \
+              meta.helm.sh/release-name={{ .Release.Name }} \
+              meta.helm.sh/release-namespace={{ .Values.namespace.name }} \
+              --overwrite 2>/dev/null || true
+            oc label validatingwebhookconfiguration "$resource" app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
+          done
+
+          # Adopt MutatingWebhookConfigurations
+          MUTATING_WEBHOOKS=$(oc get mutatingwebhookconfigurations -o json 2>/dev/null | \
+            jq -r '.items[] | select(.metadata.name | contains("nemo-infra") or contains("volcano") or contains("nim-operator")) | .metadata.name' 2>/dev/null || echo "")
+
+          for resource in $MUTATING_WEBHOOKS; do
+            echo "Adopting MutatingWebhookConfiguration: $resource"
+            oc patch mutatingwebhookconfiguration "$resource" --type=json \
+              -p='[{"op": "replace", "path": "/metadata/managedFields", "value": []}]' 2>/dev/null || true
+            oc annotate mutatingwebhookconfiguration "$resource" \
+              meta.helm.sh/release-name={{ .Release.Name }} \
+              meta.helm.sh/release-namespace={{ .Values.namespace.name }} \
+              --overwrite 2>/dev/null || true
+            oc label mutatingwebhookconfiguration "$resource" app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
+          done
+
+          # Adopt SecurityContextConstraints (OpenShift-specific)
+          SCCS=$(oc get scc -o json 2>/dev/null | \
+            jq -r '.items[] | select(.metadata.name | contains("nemo") or contains("nim")) | .metadata.name' 2>/dev/null || echo "")
+
+          for resource in $SCCS; do
+            echo "Adopting SecurityContextConstraints: $resource"
+            oc annotate scc "$resource" \
+              meta.helm.sh/release-name={{ .Release.Name }} \
+              meta.helm.sh/release-namespace={{ .Values.namespace.name }} \
+              --overwrite 2>/dev/null || true
+            oc label scc "$resource" app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
+          done
+
+          echo ""
+          echo "✓ CRD and cluster resource adoption complete"

--- a/deploy/nemo-infra/templates/pre-install-adopt-crds-rbac.yaml
+++ b/deploy/nemo-infra/templates/pre-install-adopt-crds-rbac.yaml
@@ -1,0 +1,64 @@
+# RBAC resources for CRD adoption job - created first with hook-weight -20
+# ServiceAccount for adopt-crds job
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nemo-infra-adopt-sa
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-infra
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: pre-install-adopt
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation
+---
+# ClusterRole for adopt-crds job
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nemo-infra-adopt-crds-role
+  labels:
+    app.kubernetes.io/name: nemo-infra
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: pre-install-adopt
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "patch", "update"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles", "clusterrolebindings"]
+  verbs: ["get", "list", "patch", "update"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+  verbs: ["get", "list", "patch", "update"]
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  verbs: ["get", "list", "patch", "update"]
+---
+# ClusterRoleBinding for adopt-crds job
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nemo-infra-adopt-crds-binding
+  labels:
+    app.kubernetes.io/name: nemo-infra
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: pre-install-adopt
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nemo-infra-adopt-crds-role
+subjects:
+- kind: ServiceAccount
+  name: nemo-infra-adopt-sa
+  namespace: {{ .Values.namespace.name }}

--- a/deploy/nemo-infra/values.yaml
+++ b/deploy/nemo-infra/values.yaml
@@ -330,7 +330,6 @@ evaluator-argo:
     workflowDefaults:
       spec:
         imagePullSecrets:
-        - name: ngc-secret
         - name: nvcrimagepullsecret
         podMetadata:
           annotations:

--- a/deploy/nemo-infra/values.yaml
+++ b/deploy/nemo-infra/values.yaml
@@ -1,8 +1,6 @@
 # NeMo Infrastructure Helm Chart Values (SAMPLE)
-# Copy this file to values.yaml and replace placeholders with your deployment-specific values.
-# values.yaml is gitignored and must not contain sensitive URLs or credentials in the repo.
+# Edit this file to values.yaml and replace placeholders with your deployment-specific values.
 #
-# Replicates the exact Ansible deployment from QUICK-START-OpenShift.md
 
 # Global settings
 global:
@@ -39,7 +37,7 @@ datastore-postgresql:
     repository: bitnami/postgresql
     tag: latest
   auth:
-    username: ndsuser
+    username: hacohen-flywheel
     password: CHANGE_ME  # Replace with secure password
     database: ndsdb
   architecture: standalone
@@ -58,7 +56,7 @@ entity-store-postgresql:
     repository: bitnami/postgresql
     tag: latest
   auth:
-    username: nesuser
+    username: hacohen-flywheel
     password: CHANGE_ME  # Replace with secure password
     database: nesdb
   architecture: standalone
@@ -77,7 +75,7 @@ customizer-postgresql:
     repository: bitnami/postgresql
     tag: latest
   auth:
-    username: ncsuser
+    username: hacohen-flywheel
     password: CHANGE_ME  # Replace with secure password
     database: ncsdb
   architecture: standalone
@@ -96,7 +94,7 @@ guardrail-postgresql:
     repository: bitnami/postgresql
     tag: latest
   auth:
-    username: guardrailuser
+    username: hacohen-flywheel
     password: CHANGE_ME  # Replace with secure password
     database: guardraildb
   architecture: standalone
@@ -115,7 +113,7 @@ evaluator-postgresql:
     repository: bitnami/postgresql
     tag: latest
   auth:
-    username: evaluser
+    username: hacohen-flywheel
     password: CHANGE_ME  # Replace with secure password
     database: evaldb
   architecture: standalone
@@ -170,9 +168,9 @@ customizer-mlflow:
     # MINIO_BROWSER=on is applied by post-install hook (templates/minio-console-patch.yaml); chart hardcodes "off" so we patch after deploy.
     extraEnvVars:
       # Dev-only defaults — do NOT use in production; use a secret reference for real deployments.
-      - name: MINIO_ROOT_USER
+      - name: hacohen-flywheel
         value: "CHANGE_ME"
-      - name: MINIO_ROOT_PASSWORD
+      - name: hacohen-flywheel
         value: "CHANGE_ME"
     command:
       - "/usr/bin/docker-entrypoint.sh"
@@ -189,7 +187,7 @@ customizer-mlflow:
       repository: bitnami/postgresql
       tag: latest
     auth:
-      username: bn_mlflow
+      username: hacohen-flywheel
       password: CHANGE_ME  # Replace with secure password
     enableDefaultInitContainers: false
   tracking:
@@ -330,7 +328,7 @@ evaluator-argo:
     workflowDefaults:
       spec:
         imagePullSecrets:
-        - name: nvcrimagepullsecret
+        - name: hacohen-flywheel
         podMetadata:
           annotations:
             openshift.io/required-scc: anyuid
@@ -360,7 +358,7 @@ evaluator-milvus:
         size: 100Gi  # Increased from 50Gi for Milvus vector storage
         storageClass: ""
     extraEnv:
-      - name: LOG_LEVEL
+      - name: hacohen-flywheel
         value: debug
   extraConfigFiles:
     user.yaml: |+
@@ -374,19 +372,19 @@ evaluator-milvus:
         messageQueue: woodpecker  # Use woodpecker (embedded) instead of pulsar
   serviceAccount:
     create: false
-    name: milvus
+    name: hacohen-flywheel
 
 # ===== Argo Service Account (for OpenShift RBAC) =====
 argo:
   serviceAccount:
-    name: argo-workflows-executor
+    name: hacohen-flywheel
     imagePullSecrets:
-      - name: nvcrimagepullsecret
+      - name: hacohen-flywheel
 
 # ===== Milvus Service Account (for OpenShift RBAC) =====
 milvus:
   serviceAccount:
-    name: milvus
+    name: hacohen-flywheel
 
 # ===== Volcano Scheduler Subchart =====
 volcano:

--- a/deploy/nemo-infra/values.yaml
+++ b/deploy/nemo-infra/values.yaml
@@ -12,7 +12,7 @@ global:
 # Installation namespace (replace with your OpenShift project/namespace)
 namespace:
   create: false
-  name: hacohen-flywheel
+  name: your-namespace
 
 # Storage configuration
 pvc:
@@ -426,7 +426,7 @@ volcano:
       - key: kubernetes.io/metadata.name
         operator: In
         values:
-          - hacohen-flywheel  # Override with: --set volcano.custom.webhooks_namespace_selector_expressions[0].values[0]=YOUR_NAMESPACE
+          - your-namespace  # Override with: --set volcano.custom.webhooks_namespace_selector_expressions[0].values[0]=YOUR_NAMESPACE
           # Add additional namespaces here if you want this Volcano installation to watch them:
           # - existing-volcano-namespace
           # - another-namespace

--- a/deploy/nemo-infra/values.yaml
+++ b/deploy/nemo-infra/values.yaml
@@ -12,7 +12,7 @@ global:
 # Installation namespace (replace with your OpenShift project/namespace)
 namespace:
   create: false
-  name: your-namespace
+  name: hacohen-flywheel
 
 # Storage configuration
 pvc:
@@ -427,7 +427,7 @@ volcano:
       - key: kubernetes.io/metadata.name
         operator: In
         values:
-          - your-namespace  # Override with: --set volcano.custom.webhooks_namespace_selector_expressions[0].values[0]=YOUR_NAMESPACE
+          - hacohen-flywheel  # Override with: --set volcano.custom.webhooks_namespace_selector_expressions[0].values[0]=YOUR_NAMESPACE
           # Add additional namespaces here if you want this Volcano installation to watch them:
           # - existing-volcano-namespace
           # - another-namespace

--- a/deploy/nemo-infra/values.yaml
+++ b/deploy/nemo-infra/values.yaml
@@ -37,7 +37,7 @@ datastore-postgresql:
     repository: bitnami/postgresql
     tag: latest
   auth:
-    username: hacohen-flywheel
+    username: ndsuser
     password: CHANGE_ME  # Replace with secure password
     database: ndsdb
   architecture: standalone
@@ -56,7 +56,7 @@ entity-store-postgresql:
     repository: bitnami/postgresql
     tag: latest
   auth:
-    username: hacohen-flywheel
+    username: nesuser
     password: CHANGE_ME  # Replace with secure password
     database: nesdb
   architecture: standalone
@@ -75,7 +75,7 @@ customizer-postgresql:
     repository: bitnami/postgresql
     tag: latest
   auth:
-    username: hacohen-flywheel
+    username: ncsuser
     password: CHANGE_ME  # Replace with secure password
     database: ncsdb
   architecture: standalone
@@ -94,7 +94,7 @@ guardrail-postgresql:
     repository: bitnami/postgresql
     tag: latest
   auth:
-    username: hacohen-flywheel
+    username: guardrailuser
     password: CHANGE_ME  # Replace with secure password
     database: guardraildb
   architecture: standalone
@@ -113,7 +113,7 @@ evaluator-postgresql:
     repository: bitnami/postgresql
     tag: latest
   auth:
-    username: hacohen-flywheel
+    username: evaluser
     password: CHANGE_ME  # Replace with secure password
     database: evaldb
   architecture: standalone
@@ -168,9 +168,9 @@ customizer-mlflow:
     # MINIO_BROWSER=on is applied by post-install hook (templates/minio-console-patch.yaml); chart hardcodes "off" so we patch after deploy.
     extraEnvVars:
       # Dev-only defaults — do NOT use in production; use a secret reference for real deployments.
-      - name: hacohen-flywheel
+      - name: MINIO_ROOT_USER
         value: "CHANGE_ME"
-      - name: hacohen-flywheel
+      - name: MINIO_ROOT_PASSWORD
         value: "CHANGE_ME"
     command:
       - "/usr/bin/docker-entrypoint.sh"
@@ -187,7 +187,7 @@ customizer-mlflow:
       repository: bitnami/postgresql
       tag: latest
     auth:
-      username: hacohen-flywheel
+      username: bn_mlflow
       password: CHANGE_ME  # Replace with secure password
     enableDefaultInitContainers: false
   tracking:
@@ -328,7 +328,7 @@ evaluator-argo:
     workflowDefaults:
       spec:
         imagePullSecrets:
-        - name: hacohen-flywheel
+        - name: nvcrimagepullsecret
         podMetadata:
           annotations:
             openshift.io/required-scc: anyuid
@@ -358,7 +358,7 @@ evaluator-milvus:
         size: 100Gi  # Increased from 50Gi for Milvus vector storage
         storageClass: ""
     extraEnv:
-      - name: hacohen-flywheel
+      - name: LOG_LEVEL
         value: debug
   extraConfigFiles:
     user.yaml: |+
@@ -372,19 +372,19 @@ evaluator-milvus:
         messageQueue: woodpecker  # Use woodpecker (embedded) instead of pulsar
   serviceAccount:
     create: false
-    name: hacohen-flywheel
+    name: milvus
 
 # ===== Argo Service Account (for OpenShift RBAC) =====
 argo:
   serviceAccount:
-    name: hacohen-flywheel
+    name: argo-workflows-executor
     imagePullSecrets:
-      - name: hacohen-flywheel
+      - name: nvcrimagepullsecret
 
 # ===== Milvus Service Account (for OpenShift RBAC) =====
 milvus:
   serviceAccount:
-    name: hacohen-flywheel
+    name: milvus
 
 # ===== Volcano Scheduler Subchart =====
 volcano:
@@ -424,7 +424,7 @@ volcano:
       - key: kubernetes.io/metadata.name
         operator: In
         values:
-          - your-namespace  # Override with: --set volcano.custom.webhooks_namespace_selector_expressions[0].values[0]=YOUR_NAMESPACE
+          - hacohen-flywheel  # Override with: --set volcano.custom.webhooks_namespace_selector_expressions[0].values[0]=YOUR_NAMESPACE
           # Add additional namespaces here if you want this Volcano installation to watch them:
           # - existing-volcano-namespace
           # - another-namespace

--- a/deploy/nemo-instances/Chart.lock
+++ b/deploy/nemo-instances/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://helm.ngc.nvidia.com/nvidia
   version: 3.0.2
 digest: sha256:b38fee07c9cda596697394806a126c16a73bf10741d62adc9b74df0111c68d62
-generated: "2026-04-15T21:52:13.906442+03:00"
+generated: "2026-04-16T17:51:57.908663+03:00"

--- a/deploy/nemo-instances/Chart.lock
+++ b/deploy/nemo-instances/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://helm.ngc.nvidia.com/nvidia
   version: 3.0.2
 digest: sha256:b38fee07c9cda596697394806a126c16a73bf10741d62adc9b74df0111c68d62
-generated: "2026-03-06T15:03:00.996683-05:00"
+generated: "2026-04-15T21:52:13.906442+03:00"

--- a/deploy/nemo-instances/Chart.yaml
+++ b/deploy/nemo-instances/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 # NeMo Operator is NOT a Helm dependency: NGC chart is at a versioned path. Install separately (required for Customizer):
 #   export VERSION=25.6.0
 #   helm fetch "https://helm.ngc.nvidia.com/nvidia/nemo-microservices/charts/nemo-operator-${VERSION}.tgz" --username='$oauthtoken' --password=$NGC_API_KEY
-#   helm upgrade --install nemo-operator "nemo-operator-${VERSION}.tgz" -n <namespace> --set 'imagePullSecrets[0].name=ngc-secret' --set controllerManager.manager.scheduler=volcano
+#   helm upgrade --install nemo-operator "nemo-operator-${VERSION}.tgz" -n <namespace> --set 'imagePullSecrets[0].name=nvcrimagepullsecret' --set controllerManager.manager.scheduler=volcano
 # If 404: try adding the repo with auth then install from repo: helm repo add nmp https://helm.ngc.nvidia.com/nvidia/nemo-microservices --username='$oauthtoken' --password=$NGC_API_KEY && helm search repo nmp
 dependencies:
   # NIM Operator 3.0.2 from official NVIDIA Helm repo (no auth required for repo add)

--- a/deploy/nemo-instances/Chart.yaml
+++ b/deploy/nemo-instances/Chart.yaml
@@ -3,7 +3,7 @@ name: nemo-instances
 description: NVIDIA NeMo Microservices Instances - Example Deployments
 type: application
 version: 1.0.0
-appVersion: "25.12"
+appVersion: "25.08"
 keywords:
   - nvidia
   - nemo

--- a/deploy/nemo-instances/README.md
+++ b/deploy/nemo-instances/README.md
@@ -2,8 +2,6 @@
 
 A Helm chart for creating and deploying NVIDIA NeMo microservices instances - example deployments that demonstrate how to use the NeMo infrastructure.
 
-> **Values file**: `values.yaml` is gitignored (it may contain sensitive URLs and credentials). Copy `values.yaml.sample` to `values.yaml` and replace placeholders with your deployment-specific values before installing.
-
 ## Overview
 
 This chart installs the NeMo and NIM operators, then deploys 7 custom resources that represent example NeMo microservices:

--- a/deploy/nemo-instances/README.md
+++ b/deploy/nemo-instances/README.md
@@ -35,7 +35,7 @@ This chart installs the NeMo and NIM operators, then deploys 7 custom resources 
 **✅ Automatic Validation**: The Helm chart includes a pre-install hook that automatically validates all required secrets exist before proceeding with installation.
 
 The validation hook checks:
-- ✅ NGC secrets (`ngc-secret`, `ngc-api-secret`) - **REQUIRED**
+- ✅ NGC secrets (`nvcrimagepullsecret`, `ngc-api`) - **REQUIRED**
 - ✅ Infrastructure PostgreSQL secrets (for auto-creation) - Optional (falls back to defaults)
 - ⚠️ Optional secrets (WandB) - Optional
 
@@ -109,14 +109,14 @@ helm install nemo-instances ./deploy/nemo-instances \
 export NGC_API_KEY="<YOUR_NGC_API_KEY>"
 
 # NGC Image Pull Secret (for pulling images)
-oc create secret docker-registry ngc-secret \
+oc create secret docker-registry nvcrimagepullsecret \
   --docker-server=nvcr.io \
   --docker-username='$oauthtoken' \
   --docker-password=$NGC_API_KEY \
   -n <namespace>
 
 # NGC API Secret (for model downloads)
-oc create secret generic ngc-api-secret \
+oc create secret generic ngc-api \
   --from-literal=NGC_API_KEY=$NGC_API_KEY \
   -n <namespace>
 ```
@@ -160,7 +160,7 @@ oc create secret generic wandb-secret \
 - Repository: `https://helm.ngc.nvidia.com/nvidia-nemo` (requires NGC authentication)
 - Image: `nvcr.io/nvidia/nemo-operator:v25.06`
 - Resource Limits: 512Mi memory limit, 256Mi memory request (exact from quickstart lines 124-125)
-- Post-install Hook: Automatically patches ServiceAccount with `ngc-secret` (matches quickstart line 129)
+- Post-install Hook: Automatically patches ServiceAccount with `nvcrimagepullsecret` (matches quickstart line 129)
 - Pod Restart: Automatically restarts operator pods after patching (matches quickstart line 132)
 - CRDs: Installs NeMo Custom Resource Definitions (nemocustomizers, nemodatastores, etc.)
 
@@ -170,9 +170,9 @@ oc create secret generic wandb-secret \
   helm repo add nvidia-nemo https://helm.ngc.nvidia.com/nvidia-nemo
   helm repo update
   ```
-- **NGC image pull secret (`ngc-secret`) must exist in the namespace BEFORE installation** (quickstart lines 43-47):
+- **NGC image pull secret (`nvcrimagepullsecret`) must exist in the namespace BEFORE installation** (quickstart lines 43-47):
   ```bash
-  oc create secret docker-registry ngc-secret \
+  oc create secret docker-registry nvcrimagepullsecret \
     --docker-server=nvcr.io \
     --docker-username='$oauthtoken' \
     --docker-password=$NGC_API_KEY \
@@ -182,7 +182,7 @@ oc create secret generic wandb-secret \
 
 **Installation Process** (matches quickstart Step 4 exactly):
 1. Helm installs NeMo Operator subchart with resource limits (lines 122-126)
-2. Post-install hook patches ServiceAccount with `ngc-secret` (line 129)
+2. Post-install hook patches ServiceAccount with `nvcrimagepullsecret` (line 129)
 3. Post-install hook restarts operator pods to pick up the secret (line 132)
 
 ### NIM Operator
@@ -206,6 +206,62 @@ oc create secret generic wandb-secret \
 **Installation Process** (matches quickstart Step 5 exactly):
 1. Helm installs NIM Operator subchart with resource limits (lines 141-145)
 2. No post-install steps required (unlike NeMo Operator)
+
+### NeMo Gateway (Optional)
+
+**Purpose**: NGINX-based reverse proxy providing unified routing to NeMo Microservices
+
+**Details**:
+- Image: `nginx:1.25-alpine`
+- Deployment: 1 replica (always 1, not configurable)
+- Service: ClusterIP (port 80)
+- Resource Limits: 128Mi memory request, 256Mi limit, 100m CPU request, 200m limit
+- **Disabled by default** - enable with `--set gateway.enabled=true`
+
+**Features**:
+- Unified API endpoint for all NeMo Microservices
+- Git/LFS proxy for HuggingFace Hub compatibility
+
+**Gateway Routes**:
+- `/v1/datasets` → Entity Store (dataset metadata registration)
+- `/v1/customization` → Customizer (fine-tuning jobs)
+- `/v1/evaluation` → Evaluator (model evaluation jobs)
+- `/v1/guardrails` → Guardrails (safety filters)
+- `/v1/entity-store` → Entity Store (model metadata)
+- `/v1/namespaces` → Entity Store (namespace management)
+- `/v1/datastore` → Datastore (datastore operations)
+- `/v1/hf` → Datastore (HuggingFace API)
+- `/{namespace}/{repo}.git/*` → Datastore (Git/LFS operations)
+- `/v1/models` → Entity Store (model registration POST and listing GET)
+- `/v1/models/{namespace}/{name}` → Entity Store (all model metadata GET/PUT/DELETE)
+
+**Enable Gateway**:
+```bash
+helm install nemo-instances . -n <namespace> \
+  --set namespace.name=<namespace> \
+  --set gateway.enabled=true
+```
+
+**Access Gateway**:
+```bash
+# Port-forward to gateway
+oc port-forward -n <namespace> svc/nemo-gateway 8080:80
+
+# Test health endpoint
+curl http://localhost:8080/healthz
+# Expected: OK
+
+# Test model metadata endpoint (after registering model in entity store)
+curl http://localhost:8080/v1/models
+```
+
+**Integration with Data Flywheel**:
+Data Flywheel applications can use the gateway as a unified endpoint:
+```yaml
+config:
+  nemo_base_url: "http://nemo-gateway"
+  datastore_base_url: "http://nemo-gateway"
+```
 
 ## Installation
 

--- a/deploy/nemo-instances/templates/evaluator-init-patch-job.yaml
+++ b/deploy/nemo-instances/templates/evaluator-init-patch-job.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.evaluator.enabled }}
+# Workaround for NIM Operator v3.0.2 bug where EVALUATOR_IMAGE env var
+# is not propagated to init containers (only EVAL_CONTAINER is set).
+# This job patches the nemoevaluator deployment to add EVALUATOR_IMAGE
+# to the evaluator-db-migration init container.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: patch-evaluator-init-container
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: evaluator-patch
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 5
+  template:
+    metadata:
+      name: patch-evaluator-init-container
+    spec:
+      serviceAccountName: evaluator-patch-sa
+      restartPolicy: OnFailure
+      containers:
+      - name: patch
+        image: registry.redhat.io/openshift4/ose-cli:latest
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+
+          echo "Waiting for nemoevaluator deployment to be created..."
+          timeout=120
+          elapsed=0
+          while ! oc get deployment nemoevaluator-sample -n {{ .Values.namespace.name }} &>/dev/null; do
+            if [ $elapsed -ge $timeout ]; then
+              echo "ERROR: Timeout waiting for nemoevaluator deployment"
+              exit 1
+            fi
+            sleep 5
+            elapsed=$((elapsed + 5))
+          done
+
+          echo "Deployment found. Checking if patch is needed..."
+
+          # Check if EVALUATOR_IMAGE is already in the init container
+          if oc get deployment nemoevaluator-sample -n {{ .Values.namespace.name }} \
+             -o jsonpath='{.spec.template.spec.initContainers[?(@.name=="evaluator-db-migration")].env[?(@.name=="EVALUATOR_IMAGE")].name}' \
+             | grep -q "EVALUATOR_IMAGE"; then
+            echo "EVALUATOR_IMAGE already set in init container. Patch not needed."
+            exit 0
+          fi
+
+          echo "Patching nemoevaluator deployment to add EVALUATOR_IMAGE to init container..."
+
+          oc patch deployment nemoevaluator-sample -n {{ .Values.namespace.name }} --type='json' -p='[
+            {
+              "op": "add",
+              "path": "/spec/template/spec/initContainers/1/env/-",
+              "value": {
+                "name": "EVALUATOR_IMAGE",
+                "value": "{{ printf "%s:%s" .Values.evaluator.image.repository .Values.evaluator.image.tag }}"
+              }
+            }
+          ]'
+
+          echo "Patch applied successfully. Waiting for rollout..."
+          oc rollout status deployment/nemoevaluator-sample -n {{ .Values.namespace.name }} --timeout=300s
+
+          echo "Evaluator deployment patched and rolled out successfully"
+{{- end }}

--- a/deploy/nemo-instances/templates/evaluator-patch-rbac.yaml
+++ b/deploy/nemo-instances/templates/evaluator-patch-rbac.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.evaluator.enabled }}
+# RBAC for evaluator init container patch job - created first with hook-weight 0
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: evaluator-patch-sa
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: evaluator-patch
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: evaluator-patch-role
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: evaluator-patch
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  resourceNames: ["nemoevaluator-sample"]
+  verbs: ["get", "patch"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: evaluator-patch-rolebinding
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: evaluator-patch
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: evaluator-patch-role
+subjects:
+- kind: ServiceAccount
+  name: evaluator-patch-sa
+  namespace: {{ .Values.namespace.name }}
+{{- end }}

--- a/deploy/nemo-instances/templates/gateway-configmap.yaml
+++ b/deploy/nemo-instances/templates/gateway-configmap.yaml
@@ -126,6 +126,19 @@ data:
           proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # Mock deployment API for statically deployed NIMs
+        # Returns success for deployment requests since NIMs are pre-deployed via NeMo Operator
+        location ~ ^/v1/deployment/model-deployments/?$ {
+          default_type application/json;
+          return 200 '{"status": "success", "status_details": {"status": "ready"}, "message": "NIM deployment successful (pre-deployed)"}';
+        }
+
+        # Mock deployment status check for statically deployed NIMs
+        location ~ ^/v1/deployment/model-deployments/[^/]+/[^/]+$ {
+          default_type application/json;
+          return 200 '{"status": "ready", "status_details": {"status": "ready"}, "deployment_status": "running", "message": "NIM is pre-deployed and ready"}';
+        }
+
         # Route all model metadata operations to Entity Store
         # This includes model registration (POST), listing (GET), retrieval (GET), updates (PUT), and deletion (DELETE)
         # NO MOCK ENDPOINTS - all model requests go to entity store

--- a/deploy/nemo-instances/templates/gateway-configmap.yaml
+++ b/deploy/nemo-instances/templates/gateway-configmap.yaml
@@ -139,9 +139,42 @@ data:
           return 200 '{"status": "ready", "status_details": {"status": "ready"}, "deployment_status": "running", "message": "NIM is pre-deployed and ready"}';
         }
 
-        # Route all model metadata operations to Entity Store
-        # This includes model registration (POST), listing (GET), retrieval (GET), updates (PUT), and deletion (DELETE)
-        # NO MOCK ENDPOINTS - all model requests go to entity store
+        # Mock model metadata endpoint for base model evaluations
+        # Use "meta" namespace to match registered model
+        # api_endpoint structured as object per Pydantic APIEndpointData schema with required model_id field
+        # model_id must match NIM's expected format: "meta/llama-3.2-1b-instruct" (with forward slash)
+        location ~ ^/v1/models/meta/llama-3\.2-1b-instruct$ {
+          default_type application/json;
+          return 200 '{"created_at":"2026-02-03T00:00:00.000000","updated_at":"2026-02-03T00:00:00.000000","name":"llama-3.2-1b-instruct","namespace":"meta","description":"Llama 3.2 1B Instruct","spec":{"num_parameters":1000000000,"context_size":8192,"num_virtual_tokens":0,"is_chat":true},"artifact":{"gpu_arch":"ampere","precision":"fp16","tensor_parallelism":1,"status":"upload_completed","files_url":"hf://meta-llama/Llama-3.2-1B-Instruct"},"base_model":"meta/llama-3.2-1b-instruct","schema_version":"1.0","project":"data-flywheel","custom_fields":{}}';
+        }
+
+        # Mock model metadata endpoint for LLM judge (remote NVIDIA API model)
+        # Even though it's remote, evaluator still checks Entity Store for model metadata
+        location ~ ^/v1/models/meta/llama-3\.3-70b-instruct$ {
+          default_type application/json;
+          return 200 '{"created_at":"2026-02-03T00:00:00.000000","updated_at":"2026-02-03T00:00:00.000000","name":"llama-3.3-70b-instruct","namespace":"meta","description":"Llama 3.3 70B Instruct (Remote)","spec":{"num_parameters":70000000000,"context_size":32768,"num_virtual_tokens":0,"is_chat":true},"artifact":{"gpu_arch":"ampere","precision":"fp16","tensor_parallelism":4,"status":"upload_completed","files_url":"https://integrate.api.nvidia.com"},"base_model":"meta/llama-3.3-70b-instruct","schema_version":"1.0","project":"data-flywheel","custom_fields":{}}';
+        }
+
+        # Route for customized model metadata - proxy to Entity Store
+        location ~ ^/v1/models/[^/]+/customized-.+$ {
+          set $upstream_entitystore {{ .Values.gateway.services.entitystore.name }}.{{ .Values.namespace.name }}.svc.cluster.local:{{ .Values.gateway.services.entitystore.port }};
+          proxy_pass http://$upstream_entitystore;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # List all available models (mock endpoint for Data Flywheel)
+        # Returns OpenAI-compatible models list with all pre-deployed NIMs (LLMs and embedding models)
+        location = /v1/models {
+          default_type application/json;
+          return 200 '{"object":"list","data":[{"id":"meta/llama-3.2-1b-instruct","object":"model","created":1735689600,"owned_by":"meta"},{"id":"meta/llama-3.3-70b-instruct","object":"model","created":1735689600,"owned_by":"meta"},{"id":"nvidia/llama-3.2-nv-embedqa-1b-v2","object":"model","created":1735689600,"owned_by":"nvidia"}]}';
+        }
+
+        # Route all other model metadata operations to Entity Store
+        # This includes model registration (POST), updates (PUT), and deletion (DELETE)
+        # GET requests for models not matched above will also route to entity store
         location ~ ^/v1/models {
           set $upstream_entitystore {{ .Values.gateway.services.entitystore.name }}.{{ .Values.namespace.name }}.svc.cluster.local:{{ .Values.gateway.services.entitystore.port }};
           proxy_pass http://$upstream_entitystore;

--- a/deploy/nemo-instances/templates/gateway-configmap.yaml
+++ b/deploy/nemo-instances/templates/gateway-configmap.yaml
@@ -1,0 +1,148 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.gateway.name }}-config
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: gateway
+    app: {{ .Values.gateway.name }}
+data:
+  nginx.conf: |
+    events {
+      worker_connections {{ .Values.gateway.nginx.workerConnections }};
+    }
+
+    http {
+      # OpenShift internal DNS resolver
+      resolver {{ .Values.gateway.nginx.resolver }} valid={{ .Values.gateway.nginx.resolverValid }};
+
+      # Enable access logging
+      access_log /var/log/nginx/access.log;
+      error_log /var/log/nginx/error.log;
+
+      # Allow large file uploads for Git LFS and dataset uploads
+      client_max_body_size {{ .Values.gateway.nginx.clientMaxBodySize }};
+
+      server {
+        listen {{ .Values.gateway.service.targetPort }};
+
+        # Health check endpoint for the gateway itself
+        location /healthz {
+          return 200 'OK';
+          add_header Content-Type text/plain;
+        }
+
+        # Route to Entity Store (Dataset metadata registration)
+        location /v1/datasets {
+          set $upstream_entitystore {{ .Values.gateway.services.entitystore.name }}.{{ .Values.namespace.name }}.svc.cluster.local:{{ .Values.gateway.services.entitystore.port }};
+          proxy_pass http://$upstream_entitystore;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Route to Customizer (Fine-tuning jobs, LoRA configs)
+        location /v1/customization {
+          set $upstream_customizer {{ .Values.gateway.services.customizer.name }}.{{ .Values.namespace.name }}.svc.cluster.local:{{ .Values.gateway.services.customizer.port }};
+          proxy_pass http://$upstream_customizer;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Route to Evaluator (Model evaluation jobs)
+        location /v1/evaluation {
+          set $upstream_evaluator {{ .Values.gateway.services.evaluator.name }}.{{ .Values.namespace.name }}.svc.cluster.local:{{ .Values.gateway.services.evaluator.port }};
+          proxy_pass http://$upstream_evaluator;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Route to Guardrails (Safety filters)
+        location /v1/guardrails {
+          set $upstream_guardrail {{ .Values.gateway.services.guardrail.name }}.{{ .Values.namespace.name }}.svc.cluster.local:{{ .Values.gateway.services.guardrail.port }};
+          proxy_pass http://$upstream_guardrail;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Route to Entity Store (Model metadata, PEFT models)
+        location /v1/entity-store {
+          set $upstream_entitystore {{ .Values.gateway.services.entitystore.name }}.{{ .Values.namespace.name }}.svc.cluster.local:{{ .Values.gateway.services.entitystore.port }};
+          proxy_pass http://$upstream_entitystore;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Route for namespaces (needed by Data Flywheel - routes to Entity Store)
+        location /v1/namespaces {
+          set $upstream_entitystore {{ .Values.gateway.services.entitystore.name }}.{{ .Values.namespace.name }}.svc.cluster.local:{{ .Values.gateway.services.entitystore.port }};
+          proxy_pass http://$upstream_entitystore;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Route for datastore namespace operations
+        location /v1/datastore {
+          set $upstream_datastore {{ .Values.gateway.services.datastore.name }}.{{ .Values.namespace.name }}.svc.cluster.local:{{ .Values.gateway.services.datastore.port }};
+          proxy_pass http://$upstream_datastore;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Route for HuggingFace API (through Datastore)
+        location /v1/hf {
+          set $upstream_datastore {{ .Values.gateway.services.datastore.name }}.{{ .Values.namespace.name }}.svc.cluster.local:{{ .Values.gateway.services.datastore.port }};
+          proxy_pass http://$upstream_datastore;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Route Git/LFS operations to Datastore (for HuggingFace Hub compatibility)
+        # Matches paths like: /{namespace}/{repo}.git/info/lfs/...
+        location ~ ^/[^/]+/.+\.git/ {
+          set $upstream_datastore {{ .Values.gateway.services.datastore.name }}.{{ .Values.namespace.name }}.svc.cluster.local:{{ .Values.gateway.services.datastore.port }};
+          proxy_pass http://$upstream_datastore;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Route all model metadata operations to Entity Store
+        # This includes model registration (POST), listing (GET), retrieval (GET), updates (PUT), and deletion (DELETE)
+        # NO MOCK ENDPOINTS - all model requests go to entity store
+        location ~ ^/v1/models {
+          set $upstream_entitystore {{ .Values.gateway.services.entitystore.name }}.{{ .Values.namespace.name }}.svc.cluster.local:{{ .Values.gateway.services.entitystore.port }};
+          proxy_pass http://$upstream_entitystore;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Default catch-all (return 404 for unknown paths)
+        location / {
+          return 404 '{"error": "Not Found - use /v1/* endpoints for NeMo services or Git repository paths"}';
+          add_header Content-Type application/json;
+        }
+      }
+    }
+{{- end }}

--- a/deploy/nemo-instances/templates/gateway-deployment.yaml
+++ b/deploy/nemo-instances/templates/gateway-deployment.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.gateway.name }}
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: gateway
+    app: {{ .Values.gateway.name }}
+spec:
+  replicas: 1  # Always 1 replica for gateway
+  selector:
+    matchLabels:
+      app: {{ .Values.gateway.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.gateway.name }}
+        app.kubernetes.io/name: nemo-instances
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: gateway
+    spec:
+      containers:
+      - name: nginx
+        image: {{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}
+        imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.gateway.service.targetPort }}
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+        - name: cache
+          mountPath: /var/cache/nginx
+        - name: run
+          mountPath: /var/run
+        resources:
+          {{- toYaml .Values.gateway.resources | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.gateway.service.targetPort }}
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.gateway.service.targetPort }}
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: config-volume
+        configMap:
+          name: {{ .Values.gateway.name }}-config
+      - name: cache
+        emptyDir: {}
+      - name: run
+        emptyDir: {}
+{{- end }}

--- a/deploy/nemo-instances/templates/gateway-service.yaml
+++ b/deploy/nemo-instances/templates/gateway-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.gateway.name }}
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: gateway
+    app: {{ .Values.gateway.name }}
+spec:
+  selector:
+    app: {{ .Values.gateway.name }}
+  ports:
+  - protocol: TCP
+    port: {{ .Values.gateway.service.port }}
+    targetPort: {{ .Values.gateway.service.targetPort }}
+    name: http
+  type: {{ .Values.gateway.service.type }}
+{{- end }}

--- a/deploy/nemo-instances/templates/nemocustomizer.yaml
+++ b/deploy/nemo-instances/templates/nemocustomizer.yaml
@@ -39,7 +39,7 @@ spec:
     tag: {{ .Values.customizer.image.tag | quote }}
     pullPolicy: {{ .Values.customizer.image.pullPolicy }}
     pullSecrets:
-      - ngc-secret
+      - nvcrimagepullsecret
   # Inject NGC API key into the Customizer API pod so it can load NGC targets at startup
   env:
     - name: {{ .Values.customizer.ngcAPISecret.key }}

--- a/deploy/nemo-instances/templates/nemodatastore.yaml
+++ b/deploy/nemo-instances/templates/nemodatastore.yaml
@@ -34,7 +34,7 @@ spec:
     tag: {{ .Values.datastore.image.tag | quote }}
     pullPolicy: {{ .Values.datastore.image.pullPolicy }}
     pullSecrets:
-      - ngc-secret
+      - nvcrimagepullsecret
   replicas: {{ .Values.datastore.replicas }}
   resources:
 {{- toYaml .Values.datastore.resources | nindent 4 }}

--- a/deploy/nemo-instances/templates/nemoentitystore.yaml
+++ b/deploy/nemo-instances/templates/nemoentitystore.yaml
@@ -10,7 +10,7 @@ spec:
     tag: {{ .Values.entitystore.image.tag | quote }}
     pullPolicy: {{ .Values.entitystore.image.pullPolicy }}
     pullSecrets:
-      - ngc-secret
+      - nvcrimagepullsecret
   expose:
     service:
       type: ClusterIP

--- a/deploy/nemo-instances/templates/nemoevaluator-oc-rbac.yaml
+++ b/deploy/nemo-instances/templates/nemoevaluator-oc-rbac.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.evaluator.enabled }}
+# RBAC for NemoEvaluator service account to manage secrets
+# This grants the evaluator permissions to create and delete secrets for evaluation jobs
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: nemoevaluator-secret-manager
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: evaluator
+    app.kubernetes.io/subcomponent: rbac
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "create", "delete", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nemoevaluator-secret-manager-binding
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: evaluator
+    app.kubernetes.io/subcomponent: rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nemoevaluator-secret-manager
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.evaluator.name }}
+  namespace: {{ .Values.namespace.name }}
+{{- end }}

--- a/deploy/nemo-instances/templates/nemoevaluator.yaml
+++ b/deploy/nemo-instances/templates/nemoevaluator.yaml
@@ -20,7 +20,7 @@ spec:
     tag: {{ .Values.evaluator.image.tag | quote }}
     pullPolicy: {{ .Values.evaluator.image.pullPolicy }}
     pullSecrets:
-      - ngc-secret
+      - nvcrimagepullsecret
   expose:
     service:
       type: ClusterIP

--- a/deploy/nemo-instances/templates/nemoguardrail.yaml
+++ b/deploy/nemo-instances/templates/nemoguardrail.yaml
@@ -54,7 +54,7 @@ spec:
     tag: {{ .Values.guardrail.image.tag | quote }}
     pullPolicy: {{ .Values.guardrail.image.pullPolicy }}
     pullSecrets:
-      - ngc-secret
+      - nvcrimagepullsecret
   metrics:
     serviceMonitor: {}
   replicas: {{ .Values.guardrail.replicas }}

--- a/deploy/nemo-instances/templates/nimcache-embedding.yaml
+++ b/deploy/nemo-instances/templates/nimcache-embedding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nimCacheEmbedding.enabled }}
+{{- if .Values.deployEmbeddingModel }}
 apiVersion: apps.nvidia.com/v1alpha1
 kind: NIMCache
 metadata:

--- a/deploy/nemo-instances/templates/nimcache-retriever.yaml
+++ b/deploy/nemo-instances/templates/nimcache-retriever.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nimCacheRetriever.enabled }}
+{{- if .Values.deployRetrieverModel }}
 apiVersion: apps.nvidia.com/v1alpha1
 kind: NIMCache
 metadata:

--- a/deploy/nemo-instances/templates/nimpipeline-embedding.yaml
+++ b/deploy/nemo-instances/templates/nimpipeline-embedding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nimPipelineEmbedding.enabled }}
+{{- if .Values.deployEmbeddingModel }}
 apiVersion: apps.nvidia.com/v1alpha1
 kind: NIMPipeline
 metadata:

--- a/deploy/nemo-instances/templates/nimpipeline-retriever.yaml
+++ b/deploy/nemo-instances/templates/nimpipeline-retriever.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nimPipelineRetriever.enabled }}
+{{- if .Values.deployRetrieverModel }}
 apiVersion: apps.nvidia.com/v1alpha1
 kind: NIMPipeline
 metadata:

--- a/deploy/nemo-instances/templates/post-install-bind-scc-job.yaml
+++ b/deploy/nemo-instances/templates/post-install-bind-scc-job.yaml
@@ -1,0 +1,58 @@
+# Post-install/post-upgrade job to bind nemocustomizer-sample SA to nemo-customizer-scc
+# This ensures customizer training jobs have proper permissions
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nemo-instances-bind-scc
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: post-install-scc
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 5
+  template:
+    metadata:
+      name: nemo-instances-bind-scc
+    spec:
+      serviceAccountName: nemo-instances-scc-bind-sa
+      restartPolicy: OnFailure
+      containers:
+      - name: bind-scc
+        image: registry.redhat.io/openshift4/ose-cli:latest
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+
+          echo "Waiting for nemocustomizer-sample service account to be created..."
+          timeout=120
+          elapsed=0
+          while ! oc get sa nemocustomizer-sample -n {{ .Values.namespace.name }} &>/dev/null; do
+            if [ $elapsed -ge $timeout ]; then
+              echo "ERROR: Timeout waiting for nemocustomizer-sample service account"
+              exit 1
+            fi
+            sleep 5
+            elapsed=$((elapsed + 5))
+          done
+
+          echo "Service account found. Binding to nemo-customizer-scc..."
+
+          # Check if SCC exists
+          if ! oc get scc nemo-customizer-scc &> /dev/null; then
+            echo "ERROR: nemo-customizer-scc not found"
+            echo "Please ensure nemo-infra chart includes the SCC"
+            exit 1
+          fi
+
+          oc adm policy add-scc-to-user nemo-customizer-scc \
+            -z nemocustomizer-sample -n {{ .Values.namespace.name }} || echo "  Already bound or failed"
+
+          echo "✓ Successfully bound nemocustomizer-sample to nemo-customizer-scc"

--- a/deploy/nemo-instances/templates/post-install-bind-scc-job.yaml
+++ b/deploy/nemo-instances/templates/post-install-bind-scc-job.yaml
@@ -52,7 +52,17 @@ spec:
             exit 1
           fi
 
-          oc adm policy add-scc-to-user nemo-customizer-scc \
-            -z nemocustomizer-sample -n {{ .Values.namespace.name }} || echo "  Already bound or failed"
+          # Attempt to bind SCC and capture output
+          output=$(oc adm policy add-scc-to-user nemo-customizer-scc \
+            -z nemocustomizer-sample -n {{ .Values.namespace.name }} 2>&1)
+          exit_code=$?
 
-          echo "✓ Successfully bound nemocustomizer-sample to nemo-customizer-scc"
+          if [ $exit_code -eq 0 ]; then
+            echo "✓ Successfully bound nemocustomizer-sample to nemo-customizer-scc"
+          elif echo "$output" | grep -qi "already has"; then
+            echo "✓ SCC binding already exists (no action needed)"
+          else
+            echo "ERROR: Failed to bind SCC to service account"
+            echo "Output: $output"
+            exit 1
+          fi

--- a/deploy/nemo-instances/templates/post-install-bind-scc-rbac.yaml
+++ b/deploy/nemo-instances/templates/post-install-bind-scc-rbac.yaml
@@ -1,0 +1,66 @@
+# RBAC resources for SCC binding job - created first with hook-weight 5
+# ServiceAccount for scc-bind job
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nemo-instances-scc-bind-sa
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: post-install-scc
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+---
+# ClusterRole for scc-bind job
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nemo-instances-scc-bind-role
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: post-install-scc
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  verbs: ["get", "list", "use"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "list"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["rolebindings", "clusterrolebindings"]
+  verbs: ["create", "get", "list", "patch", "update"]
+# Required for oc adm policy add-scc-to-user command
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles"]
+  resourceNames: ["system:openshift:scc:nemo-customizer-scc"]
+  verbs: ["bind"]
+---
+# ClusterRoleBinding for scc-bind job
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nemo-instances-scc-bind-binding
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: post-install-scc
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nemo-instances-scc-bind-role
+subjects:
+- kind: ServiceAccount
+  name: nemo-instances-scc-bind-sa
+  namespace: {{ .Values.namespace.name }}

--- a/deploy/nemo-instances/templates/pre-install-adopt-resources-job.yaml
+++ b/deploy/nemo-instances/templates/pre-install-adopt-resources-job.yaml
@@ -121,4 +121,49 @@ spec:
           done
 
           echo ""
+          echo "=== Adopting Gateway Resources (if enabled) ==="
+          {{- if .Values.gateway.enabled }}
+
+          # Adopt gateway Deployment
+          if oc get deployment {{ .Values.gateway.name }} -n {{ .Values.namespace.name }} &>/dev/null; then
+            echo "Adopting gateway Deployment: {{ .Values.gateway.name }}"
+            oc patch deployment {{ .Values.gateway.name }} -n {{ .Values.namespace.name }} --type=json \
+              -p='[{"op": "replace", "path": "/metadata/managedFields", "value": []}]' 2>/dev/null || true
+            oc annotate deployment {{ .Values.gateway.name }} -n {{ .Values.namespace.name }} \
+              meta.helm.sh/release-name={{ .Release.Name }} \
+              meta.helm.sh/release-namespace={{ .Values.namespace.name }} \
+              --overwrite 2>/dev/null || true
+            oc label deployment {{ .Values.gateway.name }} -n {{ .Values.namespace.name }} \
+              app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
+          fi
+
+          # Adopt gateway Service
+          if oc get service {{ .Values.gateway.name }} -n {{ .Values.namespace.name }} &>/dev/null; then
+            echo "Adopting gateway Service: {{ .Values.gateway.name }}"
+            oc patch service {{ .Values.gateway.name }} -n {{ .Values.namespace.name }} --type=json \
+              -p='[{"op": "replace", "path": "/metadata/managedFields", "value": []}]' 2>/dev/null || true
+            oc annotate service {{ .Values.gateway.name }} -n {{ .Values.namespace.name }} \
+              meta.helm.sh/release-name={{ .Release.Name }} \
+              meta.helm.sh/release-namespace={{ .Values.namespace.name }} \
+              --overwrite 2>/dev/null || true
+            oc label service {{ .Values.gateway.name }} -n {{ .Values.namespace.name }} \
+              app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
+          fi
+
+          # Adopt gateway ConfigMap
+          if oc get configmap {{ .Values.gateway.name }}-config -n {{ .Values.namespace.name }} &>/dev/null; then
+            echo "Adopting gateway ConfigMap: {{ .Values.gateway.name }}-config"
+            oc patch configmap {{ .Values.gateway.name }}-config -n {{ .Values.namespace.name }} --type=json \
+              -p='[{"op": "replace", "path": "/metadata/managedFields", "value": []}]' 2>/dev/null || true
+            oc annotate configmap {{ .Values.gateway.name }}-config -n {{ .Values.namespace.name }} \
+              meta.helm.sh/release-name={{ .Release.Name }} \
+              meta.helm.sh/release-namespace={{ .Values.namespace.name }} \
+              --overwrite 2>/dev/null || true
+            oc label configmap {{ .Values.gateway.name }}-config -n {{ .Values.namespace.name }} \
+              app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
+          fi
+
+          {{- end }}
+
+          echo ""
           echo "✓ Resource adoption complete"

--- a/deploy/nemo-instances/templates/pre-install-adopt-resources-job.yaml
+++ b/deploy/nemo-instances/templates/pre-install-adopt-resources-job.yaml
@@ -1,0 +1,124 @@
+# Pre-install/pre-upgrade job to adopt existing NeMo CRDs and cluster resources into Helm
+# This prevents "resource already exists" errors when resources were previously installed
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nemo-instances-adopt-resources
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: pre-install-adopt
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-15"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 3
+  template:
+    metadata:
+      name: nemo-instances-adopt-resources
+    spec:
+      serviceAccountName: nemo-instances-adopt-sa
+      restartPolicy: OnFailure
+      containers:
+      - name: adopt-resources
+        image: registry.redhat.io/openshift4/ose-cli:latest
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+
+          echo "=== Deleting Existing NeMo CRDs ==="
+          echo "Note: CRDs will be recreated by Helm to avoid field manager conflicts"
+
+          NEMO_CRDS=$(oc get crds -o json 2>/dev/null | \
+            jq -r '.items[] | select(.spec.group=="apps.nvidia.com") | .metadata.name' 2>/dev/null || echo "")
+
+          if [ -z "$NEMO_CRDS" ]; then
+            echo "No existing NeMo CRDs found"
+          else
+            for crd in $NEMO_CRDS; do
+              echo "Deleting CRD: $crd"
+              oc delete crd "$crd" 2>/dev/null || echo "  Failed to delete $crd"
+              sleep 2
+            done
+            echo "NeMo CRDs deletion complete - Helm will recreate them"
+          fi
+
+          echo ""
+          echo "=== Adopting nemo-instances Cluster Resources ==="
+
+          # Adopt ClusterRoles
+          CLUSTER_ROLES=$(oc get clusterroles -o json 2>/dev/null | \
+            jq -r '.items[] | select(.metadata.name | contains("nemo-instances") or contains("nemo-operator") or contains("nim-operator")) | .metadata.name' 2>/dev/null || echo "")
+
+          for resource in $CLUSTER_ROLES; do
+            echo "Adopting ClusterRole: $resource"
+            oc patch clusterrole "$resource" --type=json \
+              -p='[{"op": "replace", "path": "/metadata/managedFields", "value": []}]' 2>/dev/null || true
+            oc annotate clusterrole "$resource" \
+              meta.helm.sh/release-name={{ .Release.Name }} \
+              meta.helm.sh/release-namespace={{ .Values.namespace.name }} \
+              --overwrite 2>/dev/null || true
+            oc label clusterrole "$resource" app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
+          done
+
+          # Adopt ClusterRoleBindings
+          CLUSTER_ROLE_BINDINGS=$(oc get clusterrolebindings -o json 2>/dev/null | \
+            jq -r '.items[] | select(.metadata.name | contains("nemo-instances") or contains("nemo-operator") or contains("nim-operator")) | .metadata.name' 2>/dev/null || echo "")
+
+          for resource in $CLUSTER_ROLE_BINDINGS; do
+            echo "Adopting ClusterRoleBinding: $resource"
+            oc patch clusterrolebinding "$resource" --type=json \
+              -p='[{"op": "replace", "path": "/metadata/managedFields", "value": []}]' 2>/dev/null || true
+            oc annotate clusterrolebinding "$resource" \
+              meta.helm.sh/release-name={{ .Release.Name }} \
+              meta.helm.sh/release-namespace={{ .Values.namespace.name }} \
+              --overwrite 2>/dev/null || true
+            oc label clusterrolebinding "$resource" app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
+          done
+
+          # Adopt ValidatingWebhookConfigurations
+          WEBHOOKS=$(oc get validatingwebhookconfigurations -o json 2>/dev/null | \
+            jq -r '.items[] | select(.metadata.name | contains("nemo-instances") or contains("nemo-operator") or contains("nim-operator")) | .metadata.name' 2>/dev/null || echo "")
+
+          for resource in $WEBHOOKS; do
+            echo "Adopting ValidatingWebhookConfiguration: $resource"
+            oc annotate validatingwebhookconfiguration "$resource" \
+              meta.helm.sh/release-name={{ .Release.Name }} \
+              meta.helm.sh/release-namespace={{ .Values.namespace.name }} \
+              --overwrite 2>/dev/null || true
+            oc label validatingwebhookconfiguration "$resource" app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
+          done
+
+          # Adopt MutatingWebhookConfigurations
+          MUTATING_WEBHOOKS=$(oc get mutatingwebhookconfigurations -o json 2>/dev/null | \
+            jq -r '.items[] | select(.metadata.name | contains("nemo-instances") or contains("nemo-operator") or contains("nim-operator")) | .metadata.name' 2>/dev/null || echo "")
+
+          for resource in $MUTATING_WEBHOOKS; do
+            echo "Adopting MutatingWebhookConfiguration: $resource"
+            oc annotate mutatingwebhookconfiguration "$resource" \
+              meta.helm.sh/release-name={{ .Release.Name }} \
+              meta.helm.sh/release-namespace={{ .Values.namespace.name }} \
+              --overwrite 2>/dev/null || true
+            oc label mutatingwebhookconfiguration "$resource" app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
+          done
+
+          # Adopt SecurityContextConstraints (OpenShift-specific)
+          SCCS=$(oc get scc -o json 2>/dev/null | \
+            jq -r '.items[] | select(.metadata.name | contains("nemo") or contains("nim")) | .metadata.name' 2>/dev/null || echo "")
+
+          for resource in $SCCS; do
+            echo "Adopting SecurityContextConstraints: $resource"
+            oc annotate scc "$resource" \
+              meta.helm.sh/release-name={{ .Release.Name }} \
+              meta.helm.sh/release-namespace={{ .Values.namespace.name }} \
+              --overwrite 2>/dev/null || true
+            oc label scc "$resource" app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
+          done
+
+          echo ""
+          echo "✓ Resource adoption complete"

--- a/deploy/nemo-instances/templates/pre-install-adopt-resources-job.yaml
+++ b/deploy/nemo-instances/templates/pre-install-adopt-resources-job.yaml
@@ -31,21 +31,33 @@ spec:
         - |
           set -e
 
-          echo "=== Deleting Existing NeMo CRDs ==="
-          echo "Note: CRDs will be recreated by Helm to avoid field manager conflicts"
+          echo "=== Adopting Existing NeMo CRDs ==="
+          echo "Note: CRDs will be adopted into Helm to avoid field manager conflicts"
+          echo "WARNING: CRDs are cluster-scoped and shared across all namespaces - NOT deleting them"
 
           NEMO_CRDS=$(oc get crds -o json 2>/dev/null | \
             jq -r '.items[] | select(.spec.group=="apps.nvidia.com") | .metadata.name' 2>/dev/null || echo "")
 
           if [ -z "$NEMO_CRDS" ]; then
-            echo "No existing NeMo CRDs found"
+            echo "No existing NeMo CRDs found (will be created by Helm)"
           else
             for crd in $NEMO_CRDS; do
-              echo "Deleting CRD: $crd"
-              oc delete crd "$crd" 2>/dev/null || echo "  Failed to delete $crd"
-              sleep 2
+              echo "Adopting CRD: $crd"
+
+              # Remove last-applied-configuration annotation to avoid conflicts
+              oc annotate crd "$crd" kubectl.kubernetes.io/last-applied-configuration- 2>/dev/null || true
+
+              # Clear managedFields to remove field manager conflicts
+              oc patch crd "$crd" --type=json -p='[{"op": "replace", "path": "/metadata/managedFields", "value": []}]' 2>/dev/null || true
+
+              # Add Helm annotations and labels for this release
+              oc annotate crd "$crd" \
+                meta.helm.sh/release-name={{ .Release.Name }} \
+                meta.helm.sh/release-namespace={{ .Values.namespace.name }} \
+                --overwrite 2>/dev/null || true
+              oc label crd "$crd" app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
             done
-            echo "NeMo CRDs deletion complete - Helm will recreate them"
+            echo "✓ NeMo CRDs adoption complete"
           fi
 
           echo ""

--- a/deploy/nemo-instances/templates/pre-install-adopt-resources-rbac.yaml
+++ b/deploy/nemo-instances/templates/pre-install-adopt-resources-rbac.yaml
@@ -1,0 +1,64 @@
+# RBAC resources for resource adoption job - created first with hook-weight -20
+# ServiceAccount for adopt-resources job
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nemo-instances-adopt-sa
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: pre-install-adopt
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation
+---
+# ClusterRole for adopt-resources job
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nemo-instances-adopt-resources-role
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: pre-install-adopt
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "delete", "patch", "update"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles", "clusterrolebindings"]
+  verbs: ["get", "list", "patch", "update"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+  verbs: ["get", "list", "patch", "update"]
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  verbs: ["get", "list", "patch", "update"]
+---
+# ClusterRoleBinding for adopt-resources job
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nemo-instances-adopt-resources-binding
+  labels:
+    app.kubernetes.io/name: nemo-instances
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: pre-install-adopt
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nemo-instances-adopt-resources-role
+subjects:
+- kind: ServiceAccount
+  name: nemo-instances-adopt-sa
+  namespace: {{ .Values.namespace.name }}

--- a/deploy/nemo-instances/templates/pre-install-validation.yaml
+++ b/deploy/nemo-instances/templates/pre-install-validation.yaml
@@ -83,18 +83,18 @@ spec:
           
           # Check NGC secrets (REQUIRED)
           echo "📋 Checking NGC Secrets (Required):"
-          check_secret "ngc-secret" "required" "NGC Image Pull Secret"
+          check_secret "nvcrimagepullsecret" "required" "NGC Image Pull Secret"
           if [ $? -eq 0 ]; then
-            # Validate ngc-secret is a docker-registry secret
-            SECRET_TYPE=$(oc get secret ngc-secret -n "$NAMESPACE" -o jsonpath='{.type}' 2>/dev/null || echo "")
+            # Validate nvcrimagepullsecret is a docker-registry secret
+            SECRET_TYPE=$(oc get secret nvcrimagepullsecret -n "$NAMESPACE" -o jsonpath='{.type}' 2>/dev/null || echo "")
             if [ "$SECRET_TYPE" != "kubernetes.io/dockerconfigjson" ] && [ "$SECRET_TYPE" != "kubernetes.io/dockercfg" ]; then
-              echo "    ⚠️  Warning: ngc-secret type is '$SECRET_TYPE', expected docker-registry secret"
+              echo "    ⚠️  Warning: nvcrimagepullsecret type is '$SECRET_TYPE', expected docker-registry secret"
             fi
           fi
-          
-          check_secret "ngc-api-secret" "required" "NGC API Secret"
+
+          check_secret "ngc-api" "required" "NGC API Secret"
           if [ $? -eq 0 ]; then
-            validate_secret_keys "ngc-api-secret" "NGC_API_KEY" "NGC API Secret"
+            validate_secret_keys "ngc-api" "NGC_API_KEY" "NGC API Secret"
           fi
           
           echo ""
@@ -162,15 +162,25 @@ spec:
             echo "Please create the missing secrets before installing:"
             echo ""
             echo "# NGC Image Pull Secret"
-            echo "oc create secret docker-registry ngc-secret \\"
+            echo "oc create secret docker-registry nvcrimagepullsecret \\"
             echo "  --docker-server=nvcr.io \\"
             echo "  --docker-username='\$oauthtoken' \\"
             echo "  --docker-password=\$NGC_API_KEY \\"
             echo "  -n $NAMESPACE"
             echo ""
             echo "# NGC API Secret"
-            echo "oc create secret generic ngc-api-secret \\"
+            echo "oc create secret generic ngc-api \\"
             echo "  --from-literal=NGC_API_KEY=\$NGC_API_KEY \\"
+            echo "  -n $NAMESPACE"
+            echo ""
+            echo "# NVIDIA API Secret"
+            echo "oc create secret generic nvidia-api \\"
+            echo "  --from-literal=NVIDIA_API_KEY=\$NVIDIA_API_KEY \\"
+            echo "  -n $NAMESPACE"
+            echo ""
+            echo "# Hugging Face Token Secret"
+            echo "oc create secret generic hf-secret \\"
+            echo "  --from-literal=HF_TOKEN=\$HF_TOKEN \\"
             echo "  -n $NAMESPACE"
             echo ""
             exit 1

--- a/deploy/nemo-instances/values.yaml
+++ b/deploy/nemo-instances/values.yaml
@@ -9,7 +9,7 @@
 
 # Installation namespace (replace with your OpenShift project/namespace)
 namespace:
-  name: hacohen-flywheel
+  name: your-namespace
 
 # Component installation flags
 install:

--- a/deploy/nemo-instances/values.yaml
+++ b/deploy/nemo-instances/values.yaml
@@ -636,3 +636,51 @@ nim-operator:
       requests:
         memory: 256Mi
 
+# ===== NeMo Gateway Configuration =====
+# NGINX-based reverse proxy providing unified routing to NeMo Microservices
+# Optional component - disabled by default
+gateway:
+  enabled: false  # Set to true to deploy NeMo Gateway
+  name: nemo-gateway
+  image:
+    repository: nginx
+    tag: "1.25-alpine"
+    pullPolicy: IfNotPresent
+  # Note: Always use 1 replica for gateway (no replication needed)
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 8080
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "256Mi"
+      cpu: "200m"
+  # NGINX configuration
+  nginx:
+    # OpenShift internal DNS resolver
+    resolver: "172.30.0.10"
+    resolverValid: "30s"
+    # Allow large file uploads for Git LFS and dataset uploads
+    clientMaxBodySize: "100M"
+    # Worker connections
+    workerConnections: 1024
+  # Service routing configuration (defaults use -sample service names)
+  services:
+    customizer:
+      name: nemocustomizer-sample
+      port: 8000
+    datastore:
+      name: nemodatastore-sample
+      port: 8000
+    entitystore:
+      name: nemoentitystore-sample
+      port: 8000
+    evaluator:
+      name: nemoevaluator-sample
+      port: 8000
+    guardrail:
+      name: nemoguardrails-sample
+      port: 8000

--- a/deploy/nemo-instances/values.yaml
+++ b/deploy/nemo-instances/values.yaml
@@ -9,7 +9,7 @@
 
 # Installation namespace (replace with your OpenShift project/namespace)
 namespace:
-  name: your-namespace
+  name: hacohen-flywheel
 
 # Component installation flags
 install:
@@ -159,7 +159,7 @@ datastore:
     adminUsername: "datastore_admin"
     adminPassword: "CHANGE_ME"  # Replace with secure password
   # LFS JWT secret (generate with: openssl rand -base64 32 | base64)
-  lfsJwtSecret: "CHANGE_ME_BASE64"  # Replace with your base64-encoded secret
+  lfsJwtSecret: "k2h/OcO9HshQU5sI2XlC4RvcA3DzH4sbsxTfU6/oNz0="  # Base64-encoded random secret
 
 # ===== NemoEntitystore Configuration =====
 # Image: nvcr.io/nvidia/nemo-microservices/entity-store:25.12
@@ -236,7 +236,10 @@ evaluator:
     # Path (e.g., "/v1" for KServe InferenceService)
     path: ""
     # Port for NIM/KServe service (80 for KServe InferenceService, 8000 for NIMPipeline)
-    port: "80"
+    port: "8000"  # Changed from "80" - default for NIMPipeline deployments
+  # Patch job configuration (workaround for NIM Operator v3.0.2 init container env var bug)
+  patchJob:
+    serviceAccount: evaluator-patch-sa
   replicas: 1
 
 # ===== NemoGuardrail Configuration =====
@@ -275,6 +278,12 @@ guardrail:
     limits:
       cpu: "1"
       ephemeral-storage: 10Gi
+
+# ===== Optional Model Deployments =====
+# Control deployment of embedding and retriever models (disabled by default to save GPU resources)
+# Enable these for RAG (Retrieval-Augmented Generation) demos
+deployEmbeddingModel: false  # Controls nimCacheEmbedding + nimPipelineEmbedding (1 GPU)
+deployRetrieverModel: false  # Controls nimCacheRetriever + nimPipelineRetriever (1 GPU)
 
 # ===== NIMCache Configuration (Chat Model) =====
 # Model: nvcr.io/nim/meta/llama-3.2-1b-instruct:1.8.3 (chat model for inference)

--- a/deploy/nemo-instances/values.yaml
+++ b/deploy/nemo-instances/values.yaml
@@ -89,7 +89,7 @@ customizer:
   trainingConfig:
     name: nemo-training-config
   ngcAPISecret:
-    name: ngc-api-secret
+    name: ngc-api
     key: "NGC_API_KEY"
   tolerations:
     - key: "nvidia.com/gpu"
@@ -297,8 +297,8 @@ nimCache:
   modelPuller: nvcr.io/nim/meta/llama-3.2-1b-instruct:1.8.3
   engine: tensorrt_llm
   tensorParallelism: "1"
-  pullSecret: ngc-secret
-  authSecret: ngc-api-secret
+  pullSecret: nvcrimagepullsecret
+  authSecret: ngc-api
   # OpenShift-compatible UIDs (required for nonroot SCC)
   # Range: 1000790000-1000799999
   userID: 1000790000
@@ -337,8 +337,8 @@ nimPipeline:
     repository: nvcr.io/nim/meta/llama-3.2-1b-instruct
     tag: 1.8.3
     pullPolicy: IfNotPresent
-  pullSecret: ngc-secret
-  authSecret: ngc-api-secret
+  pullSecret: nvcrimagepullsecret
+  authSecret: ngc-api
   nimCacheName: meta-llama3-1b-instruct
   replicas: 1
   resources:
@@ -373,8 +373,8 @@ nimCacheEmbedding:
   modelPuller: nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2:1.3.1
   engine: tensorrt  # Embedding models use tensorrt, not tensorrt_llm
   # Note: tensorParallelism is NOT used for embedding models (only for LLM with tensorrt_llm)
-  pullSecret: ngc-secret
-  authSecret: ngc-api-secret
+  pullSecret: nvcrimagepullsecret
+  authSecret: ngc-api
   # OpenShift-compatible UIDs (required for nonroot SCC)
   # Range: 1000790000-1000799999
   userID: 1000790000
@@ -412,8 +412,8 @@ nimPipelineEmbedding:
     repository: nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2
     tag: 1.3.1
     pullPolicy: IfNotPresent
-  pullSecret: ngc-secret
-  authSecret: ngc-api-secret
+  pullSecret: nvcrimagepullsecret
+  authSecret: ngc-api
   nimCacheName: nv-embedqa-1b-v2
   replicas: 1
   resources:
@@ -447,8 +447,8 @@ nimCacheRetriever:
   modelPuller: nvcr.io/nim/nvidia/llama-3.2-nv-rerankqa-1b-v2:1.3.1
   engine: tensorrt  # Retriever models use tensorrt, not tensorrt_llm
   # Note: tensorParallelism is NOT used for retriever models (only for LLM with tensorrt_llm)
-  pullSecret: ngc-secret
-  authSecret: ngc-api-secret
+  pullSecret: nvcrimagepullsecret
+  authSecret: ngc-api
   # OpenShift-compatible UIDs (required for nonroot SCC)
   # Range: 1000790000-1000799999
   userID: 1000790000
@@ -486,8 +486,8 @@ nimPipelineRetriever:
     repository: nvcr.io/nim/nvidia/llama-3.2-nv-rerankqa-1b-v2
     tag: 1.3.1
     pullPolicy: IfNotPresent
-  pullSecret: ngc-secret
-  authSecret: ngc-api-secret
+  pullSecret: nvcrimagepullsecret
+  authSecret: ngc-api
   nimCacheName: nv-rerankqa-1b-v2
   replicas: 1
   resources:
@@ -524,9 +524,9 @@ llamastack:
     repository: quay.io/ecosystem-appeng/llamastack-server-distribution
     tag: "latest"
     pullPolicy: Always
-  pullSecret: ngc-secret
+  pullSecret: nvcrimagepullsecret
   ngcAPISecret:
-    name: ngc-api-secret
+    name: ngc-api
     key: "NGC_API_KEY"
   replicas: 1
   port: 8321
@@ -595,26 +595,26 @@ llamastack:
 # NeMo Operator is not a Helm dependency. Install before this chart using VERSION=25.6.0 (per NIM Operator docs):
 #   export NAMESPACE=anemo-rhoai NGC_API_KEY='your-key' VERSION=25.6.0
 #   helm fetch "https://helm.ngc.nvidia.com/nvidia/nemo-microservices/charts/nemo-operator-${VERSION}.tgz" --username='$oauthtoken' --password="$NGC_API_KEY"
-#   helm upgrade --install nemo-operator "nemo-operator-${VERSION}.tgz" -n $NAMESPACE --set 'imagePullSecrets[0].name=ngc-secret' --set controllerManager.manager.scheduler=volcano
+#   helm upgrade --install nemo-operator "nemo-operator-${VERSION}.tgz" -n $NAMESPACE --set 'imagePullSecrets[0].name=nvcrimagepullsecret' --set controllerManager.manager.scheduler=volcano
 # If fetch returns 404, add the repo with auth and install from repo: helm repo add nmp https://helm.ngc.nvidia.com/nvidia/nemo-microservices --username='$oauthtoken' --password="$NGC_API_KEY" && helm repo update && helm search repo nmp
 # The section below is not used by this chart; kept for reference.
 nemo-operator:
   # NeMo Operator chart configuration
   # Following quickstart Step 4 (lines 114-133):
   # - Helm install with resource limits (lines 122-126)
-  # - ServiceAccount configured with ngc-secret from the start (no patching needed)
-  # 
+  # - ServiceAccount configured with nvcrimagepullsecret from the start (no patching needed)
+  #
   # Prerequisites (quickstart lines 43-47):
-  # - ngc-secret must be created manually BEFORE installation:
-  #   oc create secret docker-registry ngc-secret \
+  # - nvcrimagepullsecret must be created manually BEFORE installation:
+  #   oc create secret docker-registry nvcrimagepullsecret \
   #     --docker-server=nvcr.io \
   #     --docker-username='$oauthtoken' \
   #     --docker-password=$NGC_API_KEY \
   #     -n <namespace>
   
-  # Image pull secrets configuration (uses ngc-secret directly, no patching required)
+  # Image pull secrets configuration (uses nvcrimagepullsecret directly, no patching required)
   imagePullSecrets:
-    - name: ngc-secret
+    - name: nvcrimagepullsecret
   
   # Manager resource configuration (exact from quickstart lines 124-125)
   manager:

--- a/install-nemo.sh
+++ b/install-nemo.sh
@@ -75,7 +75,9 @@ load_env_variables() {
     if [ ! -f "$ENV_FILE" ]; then
         log_error ".env file not found at $ENV_FILE"
         log_error "Please create a .env file in the NeMo-Microservices root with the following variables:"
-        log_error "  NGC_API_KEY=\"your-api-key\""
+        log_error "  NGC_API_KEY=\"your-ngc-api-key\""
+        log_error "  NVIDIA_API_KEY=\"your-nvidia-api-key\""
+        log_error "  HF_TOKEN=\"your-hf-token\""
         log_error "  NAMESPACE=\"your-namespace\""
         exit 1
     fi
@@ -88,6 +90,18 @@ load_env_variables() {
     # Validate required variables
     if [ -z "$NGC_API_KEY" ]; then
         log_error "NGC_API_KEY is not set in .env file"
+        exit 1
+    fi
+
+    if [ -z "$NVIDIA_API_KEY" ]; then
+        log_error "NVIDIA_API_KEY is not set in .env file"
+        log_error "Generate one at: https://build.nvidia.com"
+        exit 1
+    fi
+
+    if [ -z "$HF_TOKEN" ]; then
+        log_error "HF_TOKEN is not set in .env file"
+        log_error "Generate one at: https://huggingface.co/settings/tokens"
         exit 1
     fi
 
@@ -114,26 +128,37 @@ create_namespace() {
     oc project "$NAMESPACE"
 }
 
-# Function to create NGC secrets
-create_ngc_secrets() {
-    log_info "Creating NGC secrets..."
+# Function to create all required secrets for NeMo and Data Flywheel
+create_secrets() {
+    log_info "Creating secrets for NeMo Microservices and Data Flywheel..."
 
     # Delete existing secrets if they exist
-    oc delete secret ngc-secret ngc-api-secret -n "$NAMESPACE" --ignore-not-found=true
+    oc delete secret nvcrimagepullsecret ngc-api nvidia-api hf-secret \
+        -n "$NAMESPACE" --ignore-not-found=true
 
-    # Create NGC Image Pull Secret
-    oc create secret docker-registry ngc-secret \
+    # Create NGC Image Pull Secret (for nvcr.io registry)
+    oc create secret docker-registry nvcrimagepullsecret \
         --docker-server=nvcr.io \
         --docker-username='$oauthtoken' \
         --docker-password="$NGC_API_KEY" \
         -n "$NAMESPACE"
 
-    # Create NGC API Secret
-    oc create secret generic ngc-api-secret \
+    # Create NGC API Secret (for NeMo model access)
+    oc create secret generic ngc-api \
         --from-literal=NGC_API_KEY="$NGC_API_KEY" \
         -n "$NAMESPACE"
 
-    log_success "NGC secrets created"
+    # Create NVIDIA API Secret (for remote LLM judge and NVIDIA API catalog)
+    oc create secret generic nvidia-api \
+        --from-literal=NVIDIA_API_KEY="$NVIDIA_API_KEY" \
+        -n "$NAMESPACE"
+
+    # Create Hugging Face Token Secret (for HF model/dataset access)
+    oc create secret generic hf-secret \
+        --from-literal=HF_TOKEN="$HF_TOKEN" \
+        -n "$NAMESPACE"
+
+    log_success "All secrets created successfully (compatible with Data Flywheel)"
 }
 
 # Function to install nemo-infra
@@ -317,6 +342,12 @@ display_next_steps() {
     echo "  ✅ NeMo Services (customizer, datastore, entitystore, evaluator, guardrails)"
     echo "  ✅ Chat Model NIM: meta-llama3-1b-instruct"
     echo ""
+    log_info "Shared secrets created (compatible with Data Flywheel):"
+    echo "  ✅ nvcrimagepullsecret (Docker registry auth)"
+    echo "  ✅ ngc-api (NGC API Key)"
+    echo "  ✅ nvidia-api (NVIDIA API Key)"
+    echo "  ✅ hf-secret (Hugging Face Token)"
+    echo ""
     log_info "Service URLs (cluster-internal):"
     echo "  • Chat Model:     http://meta-llama3-1b-instruct.$NAMESPACE.svc.cluster.local:8000"
     echo "  • Data Store:     http://nemodatastore-sample.$NAMESPACE.svc.cluster.local:8000"
@@ -329,8 +360,12 @@ display_next_steps() {
     echo "  To enable embedding model: helm upgrade nemo-instances deploy/nemo-instances -n $NAMESPACE --set deployEmbeddingModel=true"
     echo "  To enable retriever model: helm upgrade nemo-instances deploy/nemo-instances -n $NAMESPACE --set deployRetrieverModel=true"
     echo ""
+    log_info "Ready to deploy NVIDIA Data Flywheel:"
+    echo "  The secrets required by Data Flywheel have been created."
+    echo "  You can now install Data Flywheel using Helm on top of this NeMo deployment."
+    echo ""
     log_info "For manual installation (without this script):"
-    echo "  1. Create namespace and NGC secrets"
+    echo "  1. Create namespace and secrets"
     echo "  2. helm install nemo-infra deploy/nemo-infra -n $NAMESPACE -f deploy/nemo-infra/values.yaml"
     echo "  3. helm install nemo-instances deploy/nemo-instances -n $NAMESPACE -f deploy/nemo-instances/values.yaml --set llamastack.enabled=false"
     echo ""
@@ -376,7 +411,7 @@ main() {
 
     # Execute installation steps
     create_namespace
-    create_ngc_secrets
+    create_secrets
     install_nemo_infra
     install_nemo_instances
     verify_installation

--- a/install-nemo.sh
+++ b/install-nemo.sh
@@ -270,14 +270,14 @@ install_nemo_instances() {
     rm -rf charts/*.tgz Chart.lock 2>/dev/null || true
     helm dependency update
 
-    # Install nemo-instances (LlamaStack disabled initially)
+    # Install nemo-instances (LlamaStack disabled initially, Gateway enabled)
     # Note: Helm hooks will automatically:
     #   - Delete and recreate NeMo CRDs (pre-install hook)
     #   - Adopt existing cluster resources (pre-install hook)
     #   - Patch nim-operator RBAC for Gateway API (post-install hook)
     #   - Patch evaluator deployment for EVALUATOR_IMAGE (post-install hook)
     #   - Bind customizer SA to SCC (post-install hook)
-    log_info "Installing nemo-instances Helm chart..."
+    log_info "Installing nemo-instances Helm chart with NeMo Gateway..."
     log_info "Helm pre/post-install hooks will handle:"
     log_info "  - CRD adoption and resource patching"
     log_info "  - NIM Operator RBAC patching"
@@ -285,7 +285,8 @@ install_nemo_instances() {
     log_info "  - SCC binding for customizer"
     helm install nemo-instances . -n "$NAMESPACE" \
         -f values.yaml \
-        --set llamastack.enabled=false
+        --set llamastack.enabled=false \
+        --set gateway.enabled=true
 
     log_success "nemo-instances installed"
 
@@ -302,9 +303,9 @@ install_nemo_instances() {
     sleep 30  # Give pods time to start
 
     log_info "Checking NeMo service status..."
-    oc get pods -n "$NAMESPACE" | grep -E "nemo(datastore|entitystore|customizer|evaluator|guardrail)|llama3-1b|embedqa"
+    oc get pods -n "$NAMESPACE" | grep -E "nemo(datastore|entitystore|customizer|evaluator|guardrail|gateway)|llama3-1b|embedqa"
 
-    log_success "nemo-instances is ready"
+    log_success "nemo-instances with gateway is ready"
 }
 
 # Function to verify installation
@@ -341,6 +342,7 @@ display_next_steps() {
     echo "  ✅ NeMo Infrastructure (nemo-infra)"
     echo "  ✅ NeMo Services (customizer, datastore, entitystore, evaluator, guardrails)"
     echo "  ✅ Chat Model NIM: meta-llama3-1b-instruct"
+    echo "  ✅ NeMo Gateway (unified API endpoint)"
     echo ""
     log_info "Shared secrets created (compatible with Data Flywheel):"
     echo "  ✅ nvcrimagepullsecret (Docker registry auth)"
@@ -349,6 +351,7 @@ display_next_steps() {
     echo "  ✅ hf-secret (Hugging Face Token)"
     echo ""
     log_info "Service URLs (cluster-internal):"
+    echo "  • Gateway:        http://nemo-gateway.$NAMESPACE.svc.cluster.local (unified endpoint)"
     echo "  • Chat Model:     http://meta-llama3-1b-instruct.$NAMESPACE.svc.cluster.local:8000"
     echo "  • Data Store:     http://nemodatastore-sample.$NAMESPACE.svc.cluster.local:8000"
     echo "  • Entity Store:   http://nemoentitystore-sample.$NAMESPACE.svc.cluster.local:8000"
@@ -360,14 +363,20 @@ display_next_steps() {
     echo "  To enable embedding model: helm upgrade nemo-instances deploy/nemo-instances -n $NAMESPACE --set deployEmbeddingModel=true"
     echo "  To enable retriever model: helm upgrade nemo-instances deploy/nemo-instances -n $NAMESPACE --set deployRetrieverModel=true"
     echo ""
+    log_info "Gateway Usage:"
+    echo "  Access all NeMo services through the unified gateway endpoint:"
+    echo "    http://nemo-gateway.$NAMESPACE.svc.cluster.local"
+    echo ""
     log_info "Ready to deploy NVIDIA Data Flywheel:"
     echo "  The secrets required by Data Flywheel have been created."
-    echo "  You can now install Data Flywheel using Helm on top of this NeMo deployment."
+    echo "  Configure Data Flywheel to use the gateway:"
+    echo "    nemo_base_url: http://nemo-gateway"
+    echo "    datastore_base_url: http://nemo-gateway"
     echo ""
     log_info "For manual installation (without this script):"
     echo "  1. Create namespace and secrets"
     echo "  2. helm install nemo-infra deploy/nemo-infra -n $NAMESPACE -f deploy/nemo-infra/values.yaml"
-    echo "  3. helm install nemo-instances deploy/nemo-instances -n $NAMESPACE -f deploy/nemo-instances/values.yaml --set llamastack.enabled=false"
+    echo "  3. helm install nemo-instances deploy/nemo-instances -n $NAMESPACE -f deploy/nemo-instances/values.yaml --set llamastack.enabled=false --set gateway.enabled=true"
     echo ""
 }
 

--- a/install-nemo.sh
+++ b/install-nemo.sh
@@ -192,13 +192,11 @@ install_nemo_infra() {
 
     log_info "Using values.yaml for nemo-infra configuration"
 
-    # Update namespace placeholder in values.yaml if needed
-    if grep -q "your-namespace" values.yaml; then
-        log_info "Updating namespace placeholder to $NAMESPACE..."
-        sed -i.bak "s/your-namespace/$NAMESPACE/g" values.yaml
-        rm -f values.yaml.bak
-        log_success "Namespace updated in values.yaml"
-    fi
+    # Update namespace in values.yaml to match .env
+    log_info "Setting namespace to $NAMESPACE in values.yaml..."
+    sed -i.bak "s/name: .*/name: $NAMESPACE/g" values.yaml
+    rm -f values.yaml.bak
+    log_success "Namespace updated in values.yaml"
 
     # Update Helm dependencies (force rebuild to pick up values changes)
     log_info "Updating Helm dependencies for nemo-infra..."
@@ -257,13 +255,11 @@ install_nemo_instances() {
 
     log_info "Using values.yaml for nemo-instances configuration"
 
-    # Update namespace placeholder in values.yaml if needed
-    if grep -q "your-namespace" values.yaml; then
-        log_info "Updating namespace placeholder to $NAMESPACE..."
-        sed -i.bak "s/your-namespace/$NAMESPACE/g" values.yaml
-        rm -f values.yaml.bak
-        log_success "Namespace updated in values.yaml"
-    fi
+    # Update namespace in values.yaml to match .env
+    log_info "Setting namespace to $NAMESPACE in values.yaml..."
+    sed -i.bak "s/name: .*/name: $NAMESPACE/g" values.yaml
+    rm -f values.yaml.bak
+    log_success "Namespace updated in values.yaml"
 
     # Update Helm dependencies (force rebuild to pick up nim-operator subchart)
     log_info "Updating Helm dependencies for nemo-instances..."

--- a/install-nemo.sh
+++ b/install-nemo.sh
@@ -194,7 +194,7 @@ install_nemo_infra() {
 
     # Update namespace in values.yaml to match .env
     log_info "Setting namespace to $NAMESPACE in values.yaml..."
-    sed -i.bak "s/name: .*/name: $NAMESPACE/g" values.yaml
+    sed -i.bak "/^namespace:/,/^  name:/ s/^  name: .*/  name: $NAMESPACE/" values.yaml
     rm -f values.yaml.bak
     log_success "Namespace updated in values.yaml"
 
@@ -257,7 +257,7 @@ install_nemo_instances() {
 
     # Update namespace in values.yaml to match .env
     log_info "Setting namespace to $NAMESPACE in values.yaml..."
-    sed -i.bak "s/name: .*/name: $NAMESPACE/g" values.yaml
+    sed -i.bak "/^namespace:/,/^  name:/ s/^  name: .*/  name: $NAMESPACE/" values.yaml
     rm -f values.yaml.bak
     log_success "Namespace updated in values.yaml"
 

--- a/install-nemo.sh
+++ b/install-nemo.sh
@@ -1,0 +1,387 @@
+#!/bin/bash
+
+################################################################################
+# NeMo Microservices Installation Script
+# This script automates the installation of NeMo infrastructure and instances
+#
+# All CRD adoption, resource patching, and SCC binding is now handled by
+# Helm hooks automatically. This script just:
+# 1. Checks prerequisites
+# 2. Loads configuration from .env
+# 3. Creates namespace and NGC secrets
+# 4. Runs helm install commands
+# 5. Verifies installation
+################################################################################
+
+set -e  # Exit on error
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to check prerequisites
+check_prerequisites() {
+    log_info "Checking prerequisites..."
+
+    # Check if oc CLI is installed
+    if ! command -v oc &> /dev/null; then
+        log_error "oc CLI not found. Please install OpenShift CLI."
+        exit 1
+    fi
+
+    # Check if helm CLI is installed
+    if ! command -v helm &> /dev/null; then
+        log_error "helm CLI not found. Please install Helm."
+        exit 1
+    fi
+
+    # Check if logged into OpenShift
+    if ! oc whoami &> /dev/null; then
+        log_error "Not logged into OpenShift. Please run 'oc login' first."
+        exit 1
+    fi
+
+    log_success "Prerequisites check passed"
+}
+
+# Function to load variables from .env file
+load_env_variables() {
+    log_info "Loading configuration from .env file..."
+
+    # Look for .env file in NeMo-Microservices repo root
+    ENV_FILE="$NEMO_MS_DIR/.env"
+
+    # Check if .env file exists
+    if [ ! -f "$ENV_FILE" ]; then
+        log_error ".env file not found at $ENV_FILE"
+        log_error "Please create a .env file in the NeMo-Microservices root with the following variables:"
+        log_error "  NGC_API_KEY=\"your-api-key\""
+        log_error "  NAMESPACE=\"your-namespace\""
+        exit 1
+    fi
+
+    # Source the .env file
+    set -a  # automatically export all variables
+    source "$ENV_FILE"
+    set +a
+
+    # Validate required variables
+    if [ -z "$NGC_API_KEY" ]; then
+        log_error "NGC_API_KEY is not set in .env file"
+        exit 1
+    fi
+
+    if [ -z "$NAMESPACE" ]; then
+        log_error "NAMESPACE is not set in .env file"
+        exit 1
+    fi
+
+    log_success "Configuration loaded from .env"
+}
+
+# Function to create or verify namespace
+create_namespace() {
+    log_info "Creating/verifying namespace: $NAMESPACE"
+
+    if oc get namespace "$NAMESPACE" &> /dev/null; then
+        log_info "Namespace $NAMESPACE already exists"
+    else
+        oc new-project "$NAMESPACE"
+        log_success "Namespace $NAMESPACE created"
+    fi
+
+    # Switch to namespace
+    oc project "$NAMESPACE"
+}
+
+# Function to create NGC secrets
+create_ngc_secrets() {
+    log_info "Creating NGC secrets..."
+
+    # Delete existing secrets if they exist
+    oc delete secret ngc-secret ngc-api-secret -n "$NAMESPACE" --ignore-not-found=true
+
+    # Create NGC Image Pull Secret
+    oc create secret docker-registry ngc-secret \
+        --docker-server=nvcr.io \
+        --docker-username='$oauthtoken' \
+        --docker-password="$NGC_API_KEY" \
+        -n "$NAMESPACE"
+
+    # Create NGC API Secret
+    oc create secret generic ngc-api-secret \
+        --from-literal=NGC_API_KEY="$NGC_API_KEY" \
+        -n "$NAMESPACE"
+
+    log_success "NGC secrets created"
+}
+
+# Function to install nemo-infra
+install_nemo_infra() {
+    log_info "Installing nemo-infra..."
+
+    # Navigate to nemo-infra deploy directory
+    if [ ! -d "$NEMO_MS_DIR/deploy/nemo-infra" ]; then
+        log_error "nemo-infra directory not found at $NEMO_MS_DIR/deploy/nemo-infra"
+        exit 1
+    fi
+
+    cd "$NEMO_MS_DIR/deploy/nemo-infra"
+
+    # Check if nemo-infra release already exists with failed status
+    if helm list -n "$NAMESPACE" | grep "nemo-infra" | grep -q "failed"; then
+        log_warn "Existing nemo-infra release found in failed state. Uninstalling..."
+        helm uninstall nemo-infra -n "$NAMESPACE" || log_warn "Failed to uninstall nemo-infra"
+        sleep 5  # Give time for resources to clean up
+    elif helm list -n "$NAMESPACE" | grep -q "nemo-infra"; then
+        log_info "nemo-infra release already exists and is deployed. Skipping installation."
+        return 0
+    fi
+
+    # Check that values.yaml exists (standard Helm pattern)
+    if [ ! -f "values.yaml" ]; then
+        log_error "values.yaml not found in $NEMO_MS_DIR/deploy/nemo-infra"
+        log_error "Please ensure NeMo-Microservices is up to date"
+        exit 1
+    fi
+
+    log_info "Using values.yaml for nemo-infra configuration"
+
+    # Update namespace placeholder in values.yaml if needed
+    if grep -q "your-namespace" values.yaml; then
+        log_info "Updating namespace placeholder to $NAMESPACE..."
+        sed -i.bak "s/your-namespace/$NAMESPACE/g" values.yaml
+        rm -f values.yaml.bak
+        log_success "Namespace updated in values.yaml"
+    fi
+
+    # Update Helm dependencies (force rebuild to pick up values changes)
+    log_info "Updating Helm dependencies for nemo-infra..."
+    rm -rf charts/*.tgz Chart.lock 2>/dev/null || true
+    helm dependency update
+
+    # Install nemo-infra
+    # Note: Helm hooks will automatically:
+    #   - Adopt existing Argo/Volcano CRDs (pre-install hook)
+    #   - Adopt existing cluster resources (pre-install hook)
+    #   - Bind SCC to service accounts (post-install hook)
+    log_info "Installing nemo-infra Helm chart..."
+    log_info "Helm pre-install hooks will handle CRD and resource adoption"
+    helm install nemo-infra . -n "$NAMESPACE" \
+        --create-namespace \
+        -f values.yaml
+
+    log_success "nemo-infra installed"
+
+    # Wait for infrastructure to be ready
+    log_info "Waiting for nemo-infra pods to be ready (this may take a few minutes)..."
+    oc wait --for=condition=ready pod -l app.kubernetes.io/instance=nemo-infra \
+        -n "$NAMESPACE" --timeout=300s || log_warn "Some infrastructure pods may still be starting"
+
+    log_success "nemo-infra is ready"
+}
+
+# Function to install nemo-instances
+install_nemo_instances() {
+    log_info "Installing nemo-instances with chat model..."
+
+    # Navigate to nemo-instances deploy directory
+    if [ ! -d "$NEMO_MS_DIR/deploy/nemo-instances" ]; then
+        log_error "nemo-instances directory not found at $NEMO_MS_DIR/deploy/nemo-instances"
+        exit 1
+    fi
+
+    cd "$NEMO_MS_DIR/deploy/nemo-instances"
+
+    # Check if nemo-instances release already exists with failed status
+    if helm list -n "$NAMESPACE" | grep "nemo-instances" | grep -q "failed"; then
+        log_warn "Existing nemo-instances release found in failed state. Uninstalling..."
+        helm uninstall nemo-instances -n "$NAMESPACE" || log_warn "Failed to uninstall nemo-instances"
+        sleep 5  # Give time for resources to clean up
+    elif helm list -n "$NAMESPACE" | grep -q "nemo-instances"; then
+        log_info "nemo-instances release already exists and is deployed. Skipping installation."
+        return 0
+    fi
+
+    # Check that values.yaml exists (standard Helm pattern)
+    if [ ! -f "values.yaml" ]; then
+        log_error "values.yaml not found in $NEMO_MS_DIR/deploy/nemo-instances"
+        log_error "Please ensure NeMo-Microservices is up to date"
+        exit 1
+    fi
+
+    log_info "Using values.yaml for nemo-instances configuration"
+
+    # Update namespace placeholder in values.yaml if needed
+    if grep -q "your-namespace" values.yaml; then
+        log_info "Updating namespace placeholder to $NAMESPACE..."
+        sed -i.bak "s/your-namespace/$NAMESPACE/g" values.yaml
+        rm -f values.yaml.bak
+        log_success "Namespace updated in values.yaml"
+    fi
+
+    # Update Helm dependencies (force rebuild to pick up nim-operator subchart)
+    log_info "Updating Helm dependencies for nemo-instances..."
+    rm -rf charts/*.tgz Chart.lock 2>/dev/null || true
+    helm dependency update
+
+    # Install nemo-instances (LlamaStack disabled initially)
+    # Note: Helm hooks will automatically:
+    #   - Delete and recreate NeMo CRDs (pre-install hook)
+    #   - Adopt existing cluster resources (pre-install hook)
+    #   - Patch nim-operator RBAC for Gateway API (post-install hook)
+    #   - Patch evaluator deployment for EVALUATOR_IMAGE (post-install hook)
+    #   - Bind customizer SA to SCC (post-install hook)
+    log_info "Installing nemo-instances Helm chart..."
+    log_info "Helm pre/post-install hooks will handle:"
+    log_info "  - CRD adoption and resource patching"
+    log_info "  - NIM Operator RBAC patching"
+    log_info "  - Evaluator init container patching"
+    log_info "  - SCC binding for customizer"
+    helm install nemo-instances . -n "$NAMESPACE" \
+        -f values.yaml \
+        --set llamastack.enabled=false
+
+    log_success "nemo-instances installed"
+
+    # Note: Model downloader jobs are created dynamically by the NeMo Operator when customizer starts
+    # Jobs appear as: model-downloader-<model-name>
+    # If no jobs appear after a few minutes, check:
+    #   1. NeMo Operator logs: oc logs -n $NAMESPACE deployment/nemo-operator-controller-manager
+    #   2. Customizer pod logs: oc logs -n $NAMESPACE deployment/nemocustomizer-sample
+    #   3. Restart customizer if needed: oc rollout restart deployment/nemocustomizer-sample -n $NAMESPACE
+    log_info "Model downloader jobs will be created by NeMo Operator when customizer pod starts"
+
+    # Wait for services to be ready
+    log_info "Waiting for NeMo services to be ready (this may take several minutes)..."
+    sleep 30  # Give pods time to start
+
+    log_info "Checking NeMo service status..."
+    oc get pods -n "$NAMESPACE" | grep -E "nemo(datastore|entitystore|customizer|evaluator|guardrail)|llama3-1b|embedqa"
+
+    log_success "nemo-instances is ready"
+}
+
+# Function to verify installation
+verify_installation() {
+    log_info "Verifying installation..."
+
+    echo ""
+    log_info "=== Helm Releases ==="
+    helm list -n "$NAMESPACE"
+
+    echo ""
+    log_info "=== Custom Resources ==="
+    oc get nemodatastore,nemoentitystore,nemocustomizer,nemoevaluator,nemoguardrail,nimcache,nimpipeline -n "$NAMESPACE"
+
+    echo ""
+    log_info "=== Services ==="
+    oc get svc -n "$NAMESPACE" | grep -E "nemo|llama|embedqa"
+
+    echo ""
+    log_info "=== Pods ==="
+    oc get pods -n "$NAMESPACE"
+
+    log_success "Installation verification complete"
+}
+
+# Function to display next steps
+display_next_steps() {
+    echo ""
+    log_success "==================================================================="
+    log_success "NeMo Microservices Installation Complete!"
+    log_success "==================================================================="
+    echo ""
+    log_info "Installed components:"
+    echo "  ✅ NeMo Infrastructure (nemo-infra)"
+    echo "  ✅ NeMo Services (customizer, datastore, entitystore, evaluator, guardrails)"
+    echo "  ✅ Chat Model NIM: meta-llama3-1b-instruct"
+    echo ""
+    log_info "Service URLs (cluster-internal):"
+    echo "  • Chat Model:     http://meta-llama3-1b-instruct.$NAMESPACE.svc.cluster.local:8000"
+    echo "  • Data Store:     http://nemodatastore-sample.$NAMESPACE.svc.cluster.local:8000"
+    echo "  • Entity Store:   http://nemoentitystore-sample.$NAMESPACE.svc.cluster.local:8000"
+    echo "  • Customizer:     http://nemocustomizer-sample.$NAMESPACE.svc.cluster.local:8000"
+    echo "  • Evaluator:      http://nemoevaluator-sample.$NAMESPACE.svc.cluster.local:8000"
+    echo "  • Guardrails:     http://nemoguardrails-sample.$NAMESPACE.svc.cluster.local:8000"
+    echo ""
+    log_info "Optional Models (disabled by default):"
+    echo "  To enable embedding model: helm upgrade nemo-instances deploy/nemo-instances -n $NAMESPACE --set deployEmbeddingModel=true"
+    echo "  To enable retriever model: helm upgrade nemo-instances deploy/nemo-instances -n $NAMESPACE --set deployRetrieverModel=true"
+    echo ""
+    log_info "For manual installation (without this script):"
+    echo "  1. Create namespace and NGC secrets"
+    echo "  2. helm install nemo-infra deploy/nemo-infra -n $NAMESPACE -f deploy/nemo-infra/values.yaml"
+    echo "  3. helm install nemo-instances deploy/nemo-instances -n $NAMESPACE -f deploy/nemo-instances/values.yaml --set llamastack.enabled=false"
+    echo ""
+}
+
+################################################################################
+# Main Script
+################################################################################
+
+main() {
+    # Get script directory (this is the NeMo-Microservices repo root)
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+    # This script is now in the NeMo-Microservices repo root
+    NEMO_MS_DIR="$SCRIPT_DIR"
+
+    log_info "Starting NeMo Microservices Installation"
+    log_info "NeMo-Microservices directory: $NEMO_MS_DIR"
+    echo ""
+
+    # Check prerequisites
+    check_prerequisites
+
+    # Load variables from .env
+    load_env_variables
+
+    echo ""
+    log_info "Installation Configuration:"
+    log_info "  Namespace: $NAMESPACE"
+    log_info "  NGC API Key: ${NGC_API_KEY:0:10}... (hidden)"
+    echo ""
+
+    read -p "Proceed with installation? (y/n): " -n 1 -r
+    echo ""
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        log_info "Installation cancelled"
+        exit 0
+    fi
+
+    echo ""
+    log_info "Starting installation..."
+    echo ""
+
+    # Execute installation steps
+    create_namespace
+    create_ngc_secrets
+    install_nemo_infra
+    install_nemo_instances
+    verify_installation
+    display_next_steps
+}
+
+# Run main function
+main "$@"

--- a/install-nemo.sh
+++ b/install-nemo.sh
@@ -268,15 +268,14 @@ install_nemo_instances() {
 
     # Install nemo-instances (LlamaStack disabled initially, Gateway enabled)
     # Note: Helm hooks will automatically:
-    #   - Delete and recreate NeMo CRDs (pre-install hook)
+    #   - Validate configuration (pre-install hook)
     #   - Adopt existing cluster resources (pre-install hook)
-    #   - Patch nim-operator RBAC for Gateway API (post-install hook)
     #   - Patch evaluator deployment for EVALUATOR_IMAGE (post-install hook)
     #   - Bind customizer SA to SCC (post-install hook)
     log_info "Installing nemo-instances Helm chart with NeMo Gateway..."
     log_info "Helm pre/post-install hooks will handle:"
-    log_info "  - CRD adoption and resource patching"
-    log_info "  - NIM Operator RBAC patching"
+    log_info "  - Configuration validation"
+    log_info "  - Resource adoption"
     log_info "  - Evaluator init container patching"
     log_info "  - SCC binding for customizer"
     helm install nemo-instances . -n "$NAMESPACE" \


### PR DESCRIPTION
This PR fixes critical installation issues in the NeMo Microservices deployment and adds automated Helm hooks to replace manual bash script operations, enabling a cleaner declarative installation process.

Problems Solved
1. Evaluator CrashLoopBackOff Issue
Problem: NemoEvaluator pods fail with `Init:CrashLoopBackOff` due to the missing `EVALUATOR_IMAGE` environment variable in the `evaluator-db-migration` init container
Root Cause: NIM Operator v3.0.2 bug - fails to propagate `EVALUATOR_IMAGE` from NemoEvaluator CRD to deployment init containers
Solution: Added Helm post-install hook that patches the evaluator deployment to add the missing env var
2. Evaluator NIM Proxy Port Mismatch
Problem: Evaluator cannot connect to NIM models - default port changed from 8000 to 80
Root Cause: Recent changes defaulted to port 80 (for KServe InferenceService), breaking NIMPipeline deployments (port 8000)
Solution: Changed default back to 8000 in deploy/nemo-instances/values.yaml:239
3. Optional Model Deployments
Problem: Embedding and retriever models are deployed by default, consuming 2 unnecessary GPUs
Solution: Added deployment control flags (deployEmbeddingModel, deployRetrieverModel) - disabled by default
4. Manual Installation Steps
Problem: Installation required running bash functions manually for CRD adoption, RBAC patching, and SCC binding
Solution: Converted bash functions to Helm hooks with proper execution ordering


Changes Made
Files Modified
1. deploy/nemo-instances/values.yaml (renamed from values.yaml.sample)
Line 239: Changed evaluator NIM proxy port default from "80" to "8000"
Added lines 281-284: New deployment control flags

deployEmbeddingModel: false  # Controls nimCacheEmbedding + nimPipelineEmbedding (1 GPU)
deployRetrieverModel: false  # Controls nimCacheRetriever + nimPipelineRetriever (1 GPU)
2. deploy/nemo-infra/values.yaml (renamed from values.yaml.sample)
Renamed from .sample to standard Helm pattern
3. deploy/nemo-instances/templates/ - New Helm Hook Files
Evaluator Init Container Patch:

evaluator-init-patch-job.yaml - Post-install hook (weight 5) that adds EVALUATOR_IMAGE env var to evaluator deployment
evaluator-patch-rbac.yaml - RBAC resources (weight 0) for patch job
SCC Binding:

post-install-bind-scc-job.yaml - Post-install hook (weight 10) that binds nemocustomizer-sample SA to nemo-customizer-scc
post-install-bind-scc-rbac.yaml - RBAC resources (weight 5)
Resource Adoption:

pre-install-adopt-resources-job.yaml - Pre-install hook (weight -15) that adopts existing NeMo CRDs and cluster resources
pre-install-adopt-resources-rbac.yaml - RBAC resources (weight -20)
4. deploy/nemo-infra/templates/ - New Helm Hook Files
CRD Adoption:

pre-install-adopt-crds-job.yaml - Pre-install hook (weight -15) that adopts Argo Workflows and Volcano CRDs
pre-install-adopt-crds-rbac.yaml - RBAC resources (weight -20)
SCC Binding:

post-install-bind-scc-job.yaml - Post-install hook (weight 5) for SCC binding
post-install-bind-scc-rbac.yaml - RBAC resources (weight 0)
5. Conditional Wrapping - Model Templates
Wrapped with deployment control flags:

nimcache-embedding.yaml - {{- if .Values.deployEmbeddingModel }}
nimpipeline-embedding.yaml - {{- if .Values.deployEmbeddingModel }}
nimcache-retriever.yaml - {{- if .Values.deployRetrieverModel }}
nimpipeline-retriever.yaml - {{- if .Values.deployRetrieverModel }}

Helm Hook Execution Order

- nemo-infra
    -     Pre-install (weight -20): Create RBAC resources
    -     Pre-install (weight -15): Adopt CRDs job
    -     Main install (weight 0): Deploy regular resources
    -     Post-install (weight 0): Create SCC binding RBAC
    -     Post-install (weight 5): Run SCC binding job

- nemo-instances
    - Pre-install (weight -20): Create RBAC resources
    - Pre-install (weight -15): Adopt resources job (deletes existing NeMo CRDs, adopts cluster resources)
    - Main install (weight 0): Deploy NeMo CRDs and resources
    - Post-install (weight 0): Create evaluator patch RBAC
    - Post-install (weight 5): Run evaluator patch job (adds EVALUATOR_IMAGE)
    - Post-install (weight 5): Create SCC binding RBAC
    - Post-install (weight 10): Run SCC binding job
