### PR TITLE
Add AI-assisted install/uninstall runbooks for NeMo Microservices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ demos/llamastack/Llama_Stack_NVIDIA_E2E_Flow_include_outputs.ipynb
 deploy/nemo-infra/values.yaml
 deploy/nemo-instances/values.yaml
 clear_namespace.sh
+
+.claude

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ There are no hard-coded namespaces or service URLs in the repo; all are driven b
 
 ## Installation
 
+> **Automated install/uninstall**: AI-assisted runbooks are available in [`docs/commands/`](docs/commands/).
+> These inspect the cluster, detect conflicts (CRD ownership, orphaned resources, SCC collisions),
+> and adapt the installation steps automatically.
+> - [`docs/commands/install-nemo.md`](docs/commands/install-nemo.md) — full install with conflict resolution
+> - [`docs/commands/uninstall-nemo.md`](docs/commands/uninstall-nemo.md) — full uninstall including cluster-scoped orphan cleanup
+
 ### Prerequisites
 
 Before installation, ensure you have:
@@ -317,6 +323,10 @@ oc get rolebinding customizer-scc-nemo-customizer-scc-binding -n <namespace> -o 
 - **UI-created InferenceServices**: Should use `default` ServiceAccount with `nonroot` SCC (automatically configured)
 
 ## Uninstallation
+
+> **Automated uninstall**: See [`docs/commands/uninstall-nemo.md`](docs/commands/uninstall-nemo.md)
+> for an AI-assisted runbook that handles Helm releases, stuck finalizers, and cluster-scoped
+> orphan cleanup (ClusterRoles, ClusterRoleBindings, webhooks, SCCs).
 
 ### ⚠️ Important: Uninstall Order
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -1,0 +1,52 @@
+# NeMo Operational Runbooks
+
+AI-assisted runbooks for installing and uninstalling NeMo Microservices on OpenShift.
+These are plain Markdown files with structured instructions that any AI coding assistant
+can follow. They inspect the cluster, detect conflicts, and adapt automatically.
+
+## Available Runbooks
+
+| Runbook | Description |
+|---------|-------------|
+| [install-nemo.md](install-nemo.md) | Full install with CRD conflict detection, orphaned resource cleanup, and optional component selection |
+| [uninstall-nemo.md](uninstall-nemo.md) | Full uninstall including Helm releases, stuck finalizers, and cluster-scoped orphan cleanup |
+
+## Usage
+
+### Claude Code
+
+Symlinks in `.claude/commands/` register these as slash commands. To set them up:
+
+```bash
+mkdir -p .claude/commands
+ln -s ../../docs/commands/install-nemo.md .claude/commands/install-nemo.md
+ln -s ../../docs/commands/uninstall-nemo.md .claude/commands/uninstall-nemo.md
+```
+
+Then use them as slash commands:
+
+```
+/install-nemo
+/uninstall-nemo
+```
+
+### Cursor
+
+Reference the runbook in chat with `@`:
+
+```
+@docs/commands/install-nemo.md run this on my cluster
+@docs/commands/uninstall-nemo.md clean up the hacohen-nemo namespace
+```
+
+### Other AI Tools (OpenCode, Windsurf, Copilot Chat, etc.)
+
+Attach or paste the Markdown file as context, then ask the tool to follow the instructions.
+The runbooks are self-contained and have no tool-specific syntax.
+
+## Prerequisites
+
+All runbooks expect:
+- `oc`, `helm`, and `jq` on PATH
+- An active `oc login` session to the target cluster
+- A `.env` file at the repository root with `NAMESPACE`, `NGC_API_KEY`, `NVIDIA_API_KEY`, and `HF_TOKEN`

--- a/docs/commands/install-nemo.md
+++ b/docs/commands/install-nemo.md
@@ -1,0 +1,417 @@
+---
+description: Adaptive NeMo Microservices installation on OpenShift with cluster-aware conflict resolution
+---
+
+# Install NeMo Microservices
+
+You are performing an adaptive installation of NeMo Microservices on an OpenShift cluster.
+Unlike a static bash script, you inspect the cluster state first, identify conflicts and
+incompatibilities, and adapt the installation steps accordingly.
+
+## Hard rules
+
+- NEVER print, echo, or display API keys, tokens, or secret values. Use `${VAR:0:10}...` for masked confirmation only.
+- Always use `oc`, not `kubectl`.
+- Always confirm with the user before executing destructive actions (deleting resources, uninstalling Helm releases, re-annotating SCCs).
+- Always confirm the target cluster and namespace before proceeding with installation.
+- Read all configuration from the `.env` file in the repository root. Never ask the user to type secrets.
+- Do not modify `values.yaml` files beyond the namespace substitutions in Phases 5 and 6 unless the user explicitly approves.
+
+---
+
+## Phase 1: Pre-flight
+
+Verify all prerequisites. If any check fails, stop and report what is missing.
+
+1. **CLI tools**: Confirm `oc`, `helm`, and `jq` are installed and on PATH.
+2. **Establish repo root**: Record the absolute path to the repository root as `REPO_ROOT`.
+   All subsequent `.env` sourcing must use `source "$REPO_ROOT/.env"` to avoid breakage
+   when the working directory changes (e.g. after `cd deploy/nemo-infra/`).
+3. **OpenShift login**: Run `oc whoami` and `oc whoami --show-server`. Report the logged-in user and API server.
+4. **`.env` file**: Source the `.env` at the repository root. Validate that all four required variables are set and non-empty:
+   - `NAMESPACE`
+   - `NGC_API_KEY`
+   - `NVIDIA_API_KEY`
+   - `HF_TOKEN`
+5. **Chart directories**: Confirm `deploy/nemo-infra/values.yaml` and `deploy/nemo-instances/values.yaml` exist.
+6. **User confirmation**: Display the target cluster URL and namespace. Ask the user to confirm before continuing.
+
+---
+
+## Phase 2: Cluster state discovery
+
+Collect ALL of the following before deciding on any action. Do not start remediation yet.
+
+### 2.1 Existing Helm releases
+
+```bash
+helm list -n $NAMESPACE --deployed --failed --pending --uninstalling
+```
+
+Record which nemo-related releases exist and their status (deployed / failed / pending-install).
+Note: Do NOT use `-a` or `--all` — these flags are unavailable in some Helm 3 versions.
+
+### 2.2 CRD ownership
+
+Check whether Argo Workflows and Volcano CRDs already exist on the cluster, and who manages them:
+
+```bash
+oc get crd workflows.argoproj.io -o jsonpath='{.metadata.managedFields[*].manager}' 2>/dev/null
+oc get crd jobs.batch.volcano.sh  -o jsonpath='{.metadata.managedFields[*].manager}' 2>/dev/null
+```
+
+**Why this matters:** If the CRDs exist and are managed by a field manager other than `helm`
+(e.g. `platform.opendatahub.io` from OpenDataHub), then `helm install nemo-infra` will fail
+with an SSA ownership conflict unless `--skip-crds` is passed. If the CRDs do not exist at all,
+`--skip-crds` must NOT be used or the install will fail with missing CRDs.
+
+### 2.3 Orphaned cluster-scoped resources
+
+Search for resources left behind by previous failed installs:
+
+```bash
+oc get clusterroles -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|volcano|nim-operator")) | .metadata.name'
+oc get clusterrolebindings -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|volcano|nim-operator")) | .metadata.name'
+oc get validatingwebhookconfigurations -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|volcano|nim-operator")) | .metadata.name'
+oc get mutatingwebhookconfigurations -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|volcano|nim-operator")) | .metadata.name'
+oc get scc -o json | jq -r '.items[] | select(.metadata.name | test("nemo")) | .metadata.name'
+```
+
+**Why this matters:** Orphaned cluster-scoped resources carry a `before-first-apply` field
+manager. Helm SSA cannot take ownership from this manager — patching managedFields does not
+work. The only reliable fix is to delete and let Helm recreate them cleanly.
+SCCs like `nemo-customizer-scc` can also be left behind and must be included in this scan.
+
+### 2.4 SCC state
+
+```bash
+oc get scc nemo-customizer-scc -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' 2>/dev/null
+```
+
+**Why this matters:** `nemo-customizer-scc` is defined in both the nemo-infra and nemo-instances
+charts. If nemo-infra creates it first, its `meta.helm.sh/release-name` annotation points to
+`nemo-infra`. When nemo-instances tries to install, Helm sees the SCC owned by a different
+release and fails. The annotation must be updated to `nemo-instances` before that install.
+
+### 2.5 Storage classes
+
+```bash
+oc get storageclasses -o custom-columns=NAME:.metadata.name,PROVISIONER:.provisioner,DEFAULT:.metadata.annotations.storageclass\\.kubernetes\\.io/is-default-class
+```
+
+Read the `storageClass` values from both `deploy/nemo-infra/values.yaml` and
+`deploy/nemo-instances/values.yaml`. Check whether each referenced storage class actually
+exists on the cluster.
+
+### 2.6 GPU availability
+
+```bash
+oc get nodes -o json | jq -r '.items[] | select(.status.allocatable["nvidia.com/gpu"] != null and .status.allocatable["nvidia.com/gpu"] != "0") | "\(.metadata.name)\t\(.status.allocatable["nvidia.com/gpu"]) GPUs\t\([.spec.taints[]?.key] | join(","))"'
+```
+
+Report the total allocatable GPUs. NeMo requires at minimum 1 GPU for the chat model NIM.
+If zero GPUs are allocatable, warn the user — the install will succeed but NIM pods will
+remain Pending.
+
+### 2.7 Namespace state
+
+```bash
+oc get namespace $NAMESPACE 2>/dev/null
+oc get pods -n $NAMESPACE --no-headers 2>/dev/null | wc -l
+```
+
+### Present findings
+
+Summarize ALL findings in a table:
+
+| Check | Status | Detail | Action needed |
+|-------|--------|--------|---------------|
+| ...   | ...    | ...    | ...           |
+
+Present the full remediation plan. Wait for the user to confirm before moving to Phase 3.
+
+---
+
+## Phase 3: Conflict resolution
+
+Execute ONLY the remediations identified in Phase 2. Skip any sub-step that is not needed.
+
+### 3.1 Failed Helm releases
+
+If any nemo-related releases are in `failed` state, uninstall them:
+
+```bash
+helm uninstall <release-name> -n $NAMESPACE
+sleep 5
+```
+
+### 3.2 Orphaned cluster-scoped resources
+
+If Phase 2.3 found orphaned resources, delete them. List each resource name before deleting and
+confirm with the user:
+
+```bash
+oc delete clusterrole <name> --ignore-not-found
+oc delete clusterrolebinding <name> --ignore-not-found
+oc delete validatingwebhookconfiguration <name> --ignore-not-found
+oc delete mutatingwebhookconfiguration <name> --ignore-not-found
+oc delete scc <name> --ignore-not-found
+```
+
+**Important:** After any `helm uninstall` of a failed release (Phase 3.1), re-run the
+Phase 2.3 orphaned resource scan. Uninstalling a failed release often leaves behind *new*
+orphaned cluster-scoped resources (e.g. from pre-install hooks) that must also be deleted
+before retrying the install.
+
+### 3.3 Storage class mismatch
+
+If any referenced storage class does not exist on the cluster, display the available storage
+classes and ask the user which one to use. Do NOT silently change values.yaml.
+
+---
+
+## Phase 4: Namespace and secrets
+
+1. Create the namespace if it does not exist, or switch to it if it does:
+
+```bash
+oc get namespace "$NAMESPACE" 2>/dev/null && oc project "$NAMESPACE" || oc new-project "$NAMESPACE"
+```
+
+2. Recreate the required secrets (delete-then-create to ensure clean state):
+
+```bash
+oc delete secret nvcrimagepullsecret ngc-api nvidia-api hf-secret \
+    -n "$NAMESPACE" --ignore-not-found=true
+
+oc create secret docker-registry nvcrimagepullsecret \
+    --docker-server=nvcr.io \
+    --docker-username='$oauthtoken' \
+    --docker-password="$NGC_API_KEY" \
+    -n "$NAMESPACE"
+
+oc create secret generic ngc-api \
+    --from-literal=NGC_API_KEY="$NGC_API_KEY" \
+    -n "$NAMESPACE"
+
+oc create secret generic nvidia-api \
+    --from-literal=NVIDIA_API_KEY="$NVIDIA_API_KEY" \
+    -n "$NAMESPACE"
+
+oc create secret generic hf-secret \
+    --from-literal=HF_TOKEN="$HF_TOKEN" \
+    -n "$NAMESPACE"
+```
+
+---
+
+## Phase 5: Install nemo-infra
+
+1. `cd` to `deploy/nemo-infra/`.
+
+2. Patch the namespace in values.yaml:
+
+```bash
+sed -i.bak "/^namespace:/,/^  name:/ s/^  name: .*/  name: $NAMESPACE/" values.yaml && rm -f values.yaml.bak
+```
+
+**Why this matters:** The default `namespace.name` is `your-namespace`. If not patched,
+pre-install hooks will fail with `namespaces "your-namespace" not found` and leave a
+failed release that must be uninstalled before retrying.
+
+3. Clean stale artifacts and update Helm dependencies:
+
+```bash
+rm -rf charts/*.tgz Chart.lock 2>/dev/null || true
+helm dependency update
+```
+
+4. If Phase 2.3 found orphaned cluster-scoped resources, run the cleanup now (Phase 3.2)
+   if it was not already done.
+
+5. Build the `helm install` command:
+
+```bash
+helm install nemo-infra . -n "$NAMESPACE" --create-namespace -f values.yaml
+```
+
+Add `--skip-crds` ONLY if Phase 2.2 confirmed that CRDs exist and are managed by another
+operator. If CRDs do not exist, do NOT skip them.
+
+6. Run the install command.
+
+7. **If the install fails**, the release stays in `failed` state and blocks retries with
+   `cannot reuse a name that is still in use`. Recovery flow:
+
+```bash
+helm uninstall nemo-infra -n "$NAMESPACE"
+```
+
+Then re-run the Phase 2.3 orphaned resource scan — the failed install may have created
+new orphaned ClusterRoles, ClusterRoleBindings, or webhooks from pre-install hooks.
+Delete any new orphans (Phase 3.2), fix the root cause, and retry from step 5.
+
+8. Wait for pods:
+
+```bash
+oc wait --for=condition=ready pod -l app.kubernetes.io/instance=nemo-infra \
+    -n "$NAMESPACE" --timeout=300s
+```
+
+9. If the wait times out, diagnose:
+
+```bash
+oc get pods -n "$NAMESPACE" -l app.kubernetes.io/instance=nemo-infra -o wide
+oc get events -n "$NAMESPACE" --sort-by='.lastTimestamp' --field-selector reason!=Pulled | tail -20
+```
+
+For any pod not in Running state, run `oc describe pod <name> -n $NAMESPACE` and
+`oc logs <name> -n $NAMESPACE --tail=50`. Report root causes and ask the user how to proceed.
+
+---
+
+## Phase 6: Optional component selection
+
+Before installing nemo-instances, ask the user which optional components to deploy.
+
+The core services (customizer, datastore, entitystore, evaluator, guardrail, chat model NIM)
+are always deployed. The following are optional:
+
+| Component | Default | GPU cost | Description |
+|-----------|---------|----------|-------------|
+| Gateway | disabled | 0 | NeMo Gateway — unified API endpoint for all NeMo services |
+| LlamaStack | disabled | 0 | LlamaStack integration layer |
+| Embedding Model | disabled | 1 GPU | NIM embedding model (`nvidia/nv-embedqa-e5-v5`) for RAG workflows |
+| Retriever Model | disabled | 1 GPU | NIM retriever model (`nvidia/nv-rerankqa-mistral-4b-v3`) for RAG workflows |
+
+Present the table above along with the number of available GPUs (from Phase 2.6) and ask
+the user to select which optional components to enable. Use a multi-select question.
+
+Record the selections — they will be passed as `--set` flags in Phase 7 step 5.
+
+---
+
+## Phase 7: Install nemo-instances
+
+1. `cd` to `deploy/nemo-instances/`.
+
+2. Patch the namespace in values.yaml:
+
+```bash
+sed -i.bak "/^namespace:/,/^  name:/ s/^  name: .*/  name: $NAMESPACE/" values.yaml && rm -f values.yaml.bak
+```
+
+3. Clean stale artifacts and update Helm dependencies:
+
+```bash
+rm -rf charts/*.tgz Chart.lock 2>/dev/null || true
+helm dependency update
+```
+
+4. **SCC ownership transfer** — check if `nemo-customizer-scc` exists. If it does and is
+   owned by `nemo-infra` (or was just created by Phase 5), re-annotate it for nemo-instances.
+   If it does not exist, skip this step — nemo-instances will create it directly.
+
+```bash
+if oc get scc nemo-customizer-scc &>/dev/null; then
+  oc annotate scc nemo-customizer-scc \
+      meta.helm.sh/release-name=nemo-instances \
+      meta.helm.sh/release-namespace="$NAMESPACE" \
+      --overwrite
+fi
+```
+
+5. Install nemo-instances. Build the `--set` flags based on the user's selections from Phase 6:
+
+   - Gateway: `--set gateway.enabled=true` or `--set gateway.enabled=false`
+   - LlamaStack: `--set llamastack.enabled=true` or `--set llamastack.enabled=false`
+   - Embedding Model: `--set deployEmbeddingModel=true` or omit (defaults to false)
+   - Retriever Model: `--set deployRetrieverModel=true` or omit (defaults to false)
+
+```bash
+helm install nemo-instances . -n "$NAMESPACE" \
+    -f values.yaml \
+    --set gateway.enabled=<true|false> \
+    --set llamastack.enabled=<true|false> \
+    --set deployEmbeddingModel=<true|false> \
+    --set deployRetrieverModel=<true|false>
+```
+
+6. Wait for services to start (models take time to download and load):
+
+```bash
+sleep 30
+oc get pods -n "$NAMESPACE" | grep -E "nemo(datastore|entitystore|customizer|evaluator|guardrail|gateway)|llama3-1b|embedqa"
+```
+
+7. If any pods are failing, diagnose with `oc describe pod` and `oc logs --tail=50`.
+   Common issues to check:
+   - **ImagePullBackOff**: NGC credentials invalid or image tag wrong
+   - **Pending**: No GPU nodes available, or PVC cannot be provisioned (wrong storage class)
+   - **CrashLoopBackOff**: Check logs for misconfigured environment variables or missing secrets
+   - **Init container failures**: Check init container logs separately with `oc logs <pod> -c <init-container-name>`
+
+---
+
+## Phase 8: Verification
+
+Run a comprehensive check and present the results.
+
+1. **Helm releases:**
+```bash
+helm list -n "$NAMESPACE"
+```
+
+2. **Custom resources:**
+```bash
+oc get nemodatastore,nemoentitystore,nemocustomizer,nemoevaluator,nemoguardrail,nimcache,nimpipeline -n "$NAMESPACE"
+```
+
+3. **Services:**
+```bash
+oc get svc -n "$NAMESPACE" | grep -E "nemo|llama|embedqa"
+```
+
+4. **Pod health:**
+```bash
+oc get pods -n "$NAMESPACE"
+```
+
+5. **Unhealthy pods** (anything not Running or Completed):
+```bash
+oc get pods -n "$NAMESPACE" --no-headers | grep -v -E "Running|Completed"
+```
+
+For each unhealthy pod, inspect logs and events and report the root cause.
+
+Present a final summary table:
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| nemo-infra (Helm) | ... | ... |
+| nemo-instances (Helm) | ... | ... |
+| datastore | ... | ... |
+| entitystore | ... | ... |
+| customizer | ... | ... |
+| evaluator | ... | ... |
+| guardrails | ... | ... |
+| chat model NIM | ... | ... |
+| gateway | ... | ... | *(only if enabled in Phase 6)* |
+| llamastack | ... | ... | *(only if enabled in Phase 6)* |
+| embedding model NIM | ... | ... | *(only if enabled in Phase 6)* |
+| retriever model NIM | ... | ... | *(only if enabled in Phase 6)* |
+
+Only include rows for optional components that were enabled in Phase 6.
+
+If everything is healthy, display the service URLs (cluster-internal).
+
+Core services:
+- Chat Model: `http://meta-llama3-1b-instruct.$NAMESPACE.svc.cluster.local:8000`
+- Data Store: `http://nemodatastore-sample.$NAMESPACE.svc.cluster.local:8000`
+- Entity Store: `http://nemoentitystore-sample.$NAMESPACE.svc.cluster.local:8000`
+- Customizer: `http://nemocustomizer-sample.$NAMESPACE.svc.cluster.local:8000`
+- Evaluator: `http://nemoevaluator-sample.$NAMESPACE.svc.cluster.local:8000`
+- Guardrails: `http://nemoguardrails-sample.$NAMESPACE.svc.cluster.local:8000`
+
+Optional services (only if enabled):
+- Gateway: `http://nemo-gateway.$NAMESPACE.svc.cluster.local`

--- a/docs/commands/install-nemo.md
+++ b/docs/commands/install-nemo.md
@@ -70,10 +70,10 @@ with an SSA ownership conflict unless `--skip-crds` is passed. If the CRDs do no
 Search for resources left behind by previous failed installs:
 
 ```bash
-oc get clusterroles -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|volcano|nim-operator")) | .metadata.name'
-oc get clusterrolebindings -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|volcano|nim-operator")) | .metadata.name'
-oc get validatingwebhookconfigurations -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|volcano|nim-operator")) | .metadata.name'
-oc get mutatingwebhookconfigurations -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|volcano|nim-operator")) | .metadata.name'
+oc get clusterroles -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|nemo-instances|volcano|nim-operator")) | .metadata.name'
+oc get clusterrolebindings -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|nemo-instances|volcano|nim-operator")) | .metadata.name'
+oc get validatingwebhookconfigurations -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|nemo-instances|volcano|nim-operator")) | .metadata.name'
+oc get mutatingwebhookconfigurations -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|nemo-instances|volcano|nim-operator")) | .metadata.name'
 oc get scc -o json | jq -r '.items[] | select(.metadata.name | test("nemo")) | .metadata.name'
 ```
 
@@ -175,7 +175,11 @@ classes and ask the user which one to use. Do NOT silently change values.yaml.
 1. Create the namespace if it does not exist, or switch to it if it does:
 
 ```bash
-oc get namespace "$NAMESPACE" 2>/dev/null && oc project "$NAMESPACE" || oc new-project "$NAMESPACE"
+if oc get namespace "$NAMESPACE" &>/dev/null; then
+  oc project "$NAMESPACE"
+else
+  oc new-project "$NAMESPACE"
+fi
 ```
 
 2. Recreate the required secrets (delete-then-create to ensure clean state):

--- a/docs/commands/uninstall-nemo.md
+++ b/docs/commands/uninstall-nemo.md
@@ -99,7 +99,7 @@ Delete all NeMo custom resources. Use `--wait=false` to avoid blocking on finali
 
 ```bash
 for cr in nemotrainingjobs nimservice nimcache nimpipeline nemodatastore nemocustomizer nemoentitystore nemoguardrails nemoevaluator; do
-  oc delete $cr --all -n $NAMESPACE --wait=false 2>/dev/null
+  oc delete $cr --all -n $NAMESPACE --wait=false --ignore-not-found
 done
 ```
 
@@ -110,7 +110,7 @@ If any custom resources are stuck in `Terminating`, remove their finalizers:
 ```bash
 for crd in nemotrainingjobs nimservice nimcache nimpipeline nemodatastore nemocustomizer nemoentitystore nemoguardrails nemoevaluator; do
   for resource in $(oc get $crd -n $NAMESPACE -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
-    oc patch $crd $resource -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type=merge 2>/dev/null || true
+    oc patch $crd $resource -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type=merge || true
   done
 done
 ```
@@ -140,7 +140,7 @@ Delete PVCs now that pods are gone. Remove finalizers from any that are stuck:
 oc delete pvc --all -n $NAMESPACE --wait=false
 sleep 3
 for pvc in $(oc get pvc -n $NAMESPACE -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
-  oc patch pvc $pvc -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type=merge 2>/dev/null || true
+  oc patch pvc $pvc -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type=merge || true
 done
 ```
 
@@ -184,10 +184,10 @@ Scan and delete:
 
 ```bash
 echo "=== ClusterRoles ==="
-oc get clusterroles -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|volcano|nim-operator")) | .metadata.name'
+oc get clusterroles -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|nemo-instances|volcano|nim-operator")) | .metadata.name'
 
 echo "=== ClusterRoleBindings ==="
-oc get clusterrolebindings -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|volcano|nim-operator")) | .metadata.name'
+oc get clusterrolebindings -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|nemo-instances|volcano|nim-operator")) | .metadata.name'
 ```
 
 Delete each one found (excluding OLM-managed `nim-operator-certified.v*` resources — see above):
@@ -201,10 +201,10 @@ oc delete clusterrolebinding <name> --ignore-not-found
 
 ```bash
 echo "=== ValidatingWebhooks ==="
-oc get validatingwebhookconfigurations -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|volcano|nim-operator")) | .metadata.name'
+oc get validatingwebhookconfigurations -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|nemo-instances|volcano|nim-operator")) | .metadata.name'
 
 echo "=== MutatingWebhooks ==="
-oc get mutatingwebhookconfigurations -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|volcano|nim-operator")) | .metadata.name'
+oc get mutatingwebhookconfigurations -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|nemo-instances|volcano|nim-operator")) | .metadata.name'
 ```
 
 Delete each one found:

--- a/docs/commands/uninstall-nemo.md
+++ b/docs/commands/uninstall-nemo.md
@@ -1,0 +1,279 @@
+---
+description: Uninstall NeMo Microservices from OpenShift, including orphaned cluster-scoped resources
+---
+
+# Uninstall NeMo Microservices
+
+You are performing a complete uninstall of NeMo Microservices from an OpenShift cluster.
+This removes Helm releases, custom resources, namespace-scoped resources, orphaned
+cluster-scoped resources, and optionally the namespace itself.
+
+## Hard rules
+
+- NEVER print, echo, or display API keys, tokens, or secret values.
+- Always use `oc`, not `kubectl`.
+- Always confirm the target cluster and namespace before proceeding.
+- Always confirm before deleting the namespace (Phase 5) — the user may want to keep it.
+- Read `NAMESPACE` from the `.env` file in the repository root.
+
+---
+
+## Phase 1: Pre-flight
+
+1. **CLI tools**: Confirm `oc`, `helm`, and `jq` are installed and on PATH.
+2. **Establish repo root**: Record the absolute path to the repository root as `REPO_ROOT`.
+   All subsequent `.env` sourcing must use `source "$REPO_ROOT/.env"`.
+3. **OpenShift login**: Run `oc whoami` and `oc whoami --show-server`. Report the logged-in
+   user and API server.
+4. **`.env` file**: Source the `.env` at the repository root. Validate that `NAMESPACE` is
+   set and non-empty.
+5. **Namespace exists**: Confirm the namespace exists on the cluster. If it does not exist,
+   skip to Phase 4 (cluster-scoped cleanup only) — orphaned resources may still exist even
+   if the namespace is gone.
+6. **User confirmation**: Display the target cluster URL and namespace. Show current Helm
+   releases and pod count:
+
+```bash
+helm list -n $NAMESPACE --deployed --failed --pending --uninstalling
+oc get pods -n $NAMESPACE --no-headers 2>/dev/null | wc -l
+```
+
+Ask the user to confirm before continuing.
+
+---
+
+## Phase 2: Helm release uninstall
+
+Uninstall Helm releases in reverse install order (nemo-instances first, then nemo-infra).
+
+1. **Uninstall nemo-instances** (if it exists):
+
+```bash
+helm uninstall nemo-instances -n $NAMESPACE --timeout 60s
+```
+
+2. **If nemo-instances hangs** (pre-delete hooks or finalizers can block for minutes),
+   retry with `--no-hooks`:
+
+```bash
+helm uninstall nemo-instances -n $NAMESPACE --no-hooks
+```
+
+If it is still stuck in `uninstalling` state after this, proceed to Phase 3 — the
+resource-level cleanup will force-remove what Helm could not.
+
+3. **Uninstall nemo-infra** (if it exists):
+
+```bash
+helm uninstall nemo-infra -n $NAMESPACE --no-hooks
+```
+
+Use `--no-hooks` by default for nemo-infra — its hooks are not needed during teardown
+and avoiding them prevents the same hang.
+
+4. Wait briefly for Helm-managed resources to begin terminating:
+
+```bash
+sleep 5
+```
+
+---
+
+## Phase 3: Namespace-scoped resource cleanup
+
+Clean up resources that Helm may have left behind (finalizers, stuck CRs, etc.).
+Skip this phase if the namespace does not exist.
+
+### 3.1 Webhooks that block deletion
+
+Delete webhooks first — they can block resource deletion:
+
+```bash
+oc delete validatingwebhookconfiguration k8s-nim-operator-validating-webhook-configuration --ignore-not-found
+oc delete mutatingwebhookconfiguration k8s-nim-operator-mutating-webhook-configuration --ignore-not-found
+```
+
+### 3.2 Custom resources
+
+Delete all NeMo custom resources. Use `--wait=false` to avoid blocking on finalizers:
+
+```bash
+for cr in nemotrainingjobs nimservice nimcache nimpipeline nemodatastore nemocustomizer nemoentitystore nemoguardrails nemoevaluator; do
+  oc delete $cr --all -n $NAMESPACE --wait=false 2>/dev/null
+done
+```
+
+### 3.3 Remove finalizers from stuck custom resources
+
+If any custom resources are stuck in `Terminating`, remove their finalizers:
+
+```bash
+for crd in nemotrainingjobs nimservice nimcache nimpipeline nemodatastore nemocustomizer nemoentitystore nemoguardrails nemoevaluator; do
+  for resource in $(oc get $crd -n $NAMESPACE -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+    oc patch $crd $resource -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type=merge 2>/dev/null || true
+  done
+done
+```
+
+### 3.4 Workloads
+
+```bash
+oc delete deployment --all -n $NAMESPACE --wait=false
+oc delete statefulsets --all -n $NAMESPACE --wait=false
+oc delete job --all -n $NAMESPACE --wait=false
+```
+
+### 3.5 Pods
+
+Force-delete all remaining pods to release PVC locks:
+
+```bash
+oc delete pod --all -n $NAMESPACE --force --grace-period=0
+sleep 5
+```
+
+### 3.6 PVCs
+
+Delete PVCs now that pods are gone. Remove finalizers from any that are stuck:
+
+```bash
+oc delete pvc --all -n $NAMESPACE --wait=false
+sleep 3
+for pvc in $(oc get pvc -n $NAMESPACE -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+  oc patch pvc $pvc -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type=merge 2>/dev/null || true
+done
+```
+
+### 3.7 Remaining resources
+
+```bash
+oc delete service --all -n $NAMESPACE
+oc delete configmap --all -n $NAMESPACE
+oc delete secret --all -n $NAMESPACE
+```
+
+### 3.8 Verify namespace is clean
+
+```bash
+oc get all -n $NAMESPACE 2>/dev/null
+```
+
+Report any resources still remaining.
+
+---
+
+## Phase 4: Cluster-scoped resource cleanup
+
+These resources live outside the namespace and are left behind by Helm uninstalls.
+They MUST be cleaned up or future installs will fail with SSA ownership conflicts.
+
+**Important:** Resources whose names match `nim-operator-certified.v*` may be managed by the
+cluster-wide OLM NIM operator subscription, not by our Helm install. Before deleting them,
+check if a NIM operator CSV exists on the cluster:
+
+```bash
+oc get csv --all-namespaces 2>/dev/null | grep -c nim-operator-certified
+```
+
+If the count is non-zero, the OLM operator is installed cluster-wide and those resources
+will be recreated immediately after deletion. **Skip them** — they are not our orphans.
+
+### 4.1 ClusterRoles and ClusterRoleBindings
+
+Scan and delete:
+
+```bash
+echo "=== ClusterRoles ==="
+oc get clusterroles -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|volcano|nim-operator")) | .metadata.name'
+
+echo "=== ClusterRoleBindings ==="
+oc get clusterrolebindings -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|volcano|nim-operator")) | .metadata.name'
+```
+
+Delete each one found (excluding OLM-managed `nim-operator-certified.v*` resources — see above):
+
+```bash
+oc delete clusterrole <name> --ignore-not-found
+oc delete clusterrolebinding <name> --ignore-not-found
+```
+
+### 4.2 Webhook configurations
+
+```bash
+echo "=== ValidatingWebhooks ==="
+oc get validatingwebhookconfigurations -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|volcano|nim-operator")) | .metadata.name'
+
+echo "=== MutatingWebhooks ==="
+oc get mutatingwebhookconfigurations -o json | jq -r '.items[] | select(.metadata.name | test("nemo-infra|volcano|nim-operator")) | .metadata.name'
+```
+
+Delete each one found:
+
+```bash
+oc delete validatingwebhookconfiguration <name> --ignore-not-found
+oc delete mutatingwebhookconfiguration <name> --ignore-not-found
+```
+
+### 4.3 SecurityContextConstraints
+
+```bash
+oc get scc -o json | jq -r '.items[] | select(.metadata.name | test("nemo")) | .metadata.name'
+```
+
+Delete each one found:
+
+```bash
+oc delete scc <name> --ignore-not-found
+```
+
+### 4.4 Verify no orphans remain
+
+Re-run all four scans. If anything still shows up that is not OLM-managed, delete it and
+scan again.
+
+**Note:** If the nemo-instances Helm release was stuck in `uninstalling` state during
+Phase 2, it may still be finalizing in the background and recreating cluster-scoped
+resources as it processes. Re-run the scan 2-3 times with a short pause between each
+until the results stabilize. Only resources that persist after the Helm release is fully
+gone are true orphans.
+
+---
+
+## Phase 5: Namespace deletion (optional)
+
+Ask the user whether to delete the namespace.
+
+If yes:
+
+```bash
+oc delete project $NAMESPACE --wait=false
+sleep 5
+```
+
+If the namespace gets stuck in `Terminating`:
+
+```bash
+if oc get namespace $NAMESPACE 2>/dev/null; then
+  oc patch namespace $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type=merge 2>/dev/null || true
+fi
+```
+
+---
+
+## Phase 6: Final verification
+
+Present a summary table:
+
+| Area | Status | Detail |
+|------|--------|--------|
+| Helm releases | ... | nemo-infra, nemo-instances |
+| Custom resources | ... | All NeMo CRs deleted |
+| Pods / workloads | ... | None remaining |
+| PVCs | ... | All deleted |
+| ClusterRoles | ... | Orphans removed |
+| ClusterRoleBindings | ... | Orphans removed |
+| Webhooks | ... | Orphans removed |
+| SCCs | ... | Orphans removed |
+| Namespace | ... | Deleted / Kept |
+
+Report the final state. If anything remains, list it explicitly.


### PR DESCRIPTION
## Problem

Installing NeMo Microservices on OpenShift has been a fragile, error-prone process. The manual steps in the README don't cover the real-world issues that consistently break installations:

- CRD ownership conflicts: Argo and Volcano CRDs already exist on shared clusters (managed by OpenDataHub), causing Helm SSA failures unless --skip-crds is used — but skipping CRDs on a clean cluster also fails
- Orphaned cluster-scoped resources: Failed installs leave behind ClusterRoles, ClusterRoleBindings, webhooks, and SCCs with a before-first-apply field manager that blocks all future installs. Patching managedFields doesn't work — only deletion does
- SCC ownership collisions: nemo-customizer-scc is defined in both Helm charts, so whichever installs second fails unless the annotation is transferred
- Hardcoded placeholder namespace: values.yaml ships with namespace.name: your-namespace, and if you forget to patch it, the pre-install hooks fail silently, leaving a failed Helm release that blocks retries
- Uninstall hangs indefinitely: helm uninstall nemo-instances blocks on pre-delete hooks and finalizers, and after timing out, leaves orphaned cluster-scoped resources that aren't cleaned up

Each of these has been hit repeatedly. The existing README and scripts only cover the happy path.

## Solution

Two operational runbooks in docs/commands/ that any AI coding assistant (Claude Code, Cursor, OpenCode, etc.) can follow. They inspect the cluster first, detect all of the above conflicts, and adapt the install/uninstall steps accordingly.

- install-nemo.md — 8-phase install: pre-flight, cluster discovery, conflict resolution, namespace/secrets, nemo-infra install (with retry flow), optional component selection, nemo-instances install, verification
- uninstall-nemo.md — 6-phase uninstall: pre-flight, Helm release removal (with --no-hooks fallback), namespace cleanup with finalizer removal, cluster-scoped orphan cleanup, optional namespace deletion, verification

Both are plain Markdown with no tool-specific syntax. Claude Code gets them as /install-nemo and /uninstall-nemo slash commands via symlinks in .claude/commands/.

## Changes

- docs/commands/install-nemo.md — install runbook
- docs/commands/uninstall-nemo.md — uninstall runbook
- docs/commands/README.md — usage instructions for Claude Code, Cursor, and other tools
- README.md — added callouts in Installation and Uninstallation sections pointing to the runbooks
- .gitignore — updated for .claude/ directory

## Test plan

- [x] Ran full install on ai-dev01 cluster using the runbook — hit and resolved CRD conflicts, orphaned resources, namespace placeholder issue, SCC transfer
- [x] Ran full uninstall using the runbook — handled hung helm uninstall, finalizer cleanup, cluster-scoped orphan removal
- [x] Iterated on both runbooks based on the actual failure modes encountered during testing